### PR TITLE
Fixes #44

### DIFF
--- a/lib/globalize.js
+++ b/lib/globalize.js
@@ -1492,16 +1492,28 @@ Globalize.parseFloat = function( value, radix, cultureSelector ) {
 		ret = parseInt( value, 16 );
 	}
 	else {
+
+		// determine sign and number
 		var signInfo = parseNegativePattern( value, nf, nf.pattern[0] ),
 			sign = signInfo[ 0 ],
 			num = signInfo[ 1 ];
-		// determine sign and number
+
+		// #44 - try parsing as "(n)"
+		if ( sign === "" && nf.pattern[0] !== "(n)" ) {
+			signInfo = parseNegativePattern( value, nf, "(n)" );
+			sign = signInfo[ 0 ];
+			num = signInfo[ 1 ];
+		}
+
+		// try parsing as "-n"
 		if ( sign === "" && nf.pattern[0] !== "-n" ) {
 			signInfo = parseNegativePattern( value, nf, "-n" );
 			sign = signInfo[ 0 ];
 			num = signInfo[ 1 ];
 		}
+
 		sign = sign || "+";
+
 		// determine exponent and number
 		var exponent,
 			intAndFraction,

--- a/test/parse.js
+++ b/test/parse.js
@@ -14,6 +14,12 @@ test("basics, currency", function() {
 	equal( Globalize.parseFloat("$5.51"), 5.51 );
 	equal( Globalize.parseInt("($5.51)"), -5 );
 	equal( Globalize.parseFloat("($5.51)"), -5.51 );
+
+	// #44 - The cultures "lo" and "lo-LA" are unique in that they
+	// use the format "(n)" in both currency and number formatting
+	equal( Globalize.parseInt("(5.51₭)", "lo"), -5 );
+	equal( Globalize.parseFloat("(5.51₭)", "lo"), -5.51 );
+
 	equal( Globalize.parseInt("5,51 €", 10, "de-DE"), 5 );
 	equal( Globalize.parseFloat("5,51 €", 10, "de-DE"), 5.51 );
 	equal( Globalize.parseFloat("5,51 €", "de-DE"), 5.51, "optional radix" );


### PR DESCRIPTION
The parseInt and parseFloat functions failed on negative currency
patterns with parentheses for cultures whose number formatting rules did
not contain parentheses (for example, "en"). The fix was to simply
attempt to parse the numbers using the pattern "(n)" if a sign was not
found using their default number pattern.

Not sure this is the best fix because it is not at all DRY, but a proper fix would take a lot of cleaning in the parseFloat method.
