### PR TITLE
Fixes #47 - parseInt and parseFloat should return NaN instead of 0

### DIFF
--- a/lib/globalize.js
+++ b/lib/globalize.js
@@ -374,7 +374,7 @@ trim = function( value ) {
 };
 
 truncate = function( value ) {
-	return value | 0;
+	return isNaN( value ) ? NaN : value | 0;
 };
 
 zeroPad = function( str, count, left ) {

--- a/test/parse.js
+++ b/test/parse.js
@@ -20,6 +20,10 @@ test("basics, currency", function() {
 	equal( Globalize.parseInt("(5.51₭)", "lo"), -5 );
 	equal( Globalize.parseFloat("(5.51₭)", "lo"), -5.51 );
 
+	// #47 - Return NaN instead of 0 for invalid values
+	equal( String( Globalize.parseInt("foo") ), "NaN" );
+	equal( String( Globalize.parseFloat("foo") ), "NaN" );
+
 	equal( Globalize.parseInt("5,51 €", 10, "de-DE"), 5 );
 	equal( Globalize.parseFloat("5,51 €", 10, "de-DE"), 5.51 );
 	equal( Globalize.parseFloat("5,51 €", "de-DE"), 5.51, "optional radix" );


### PR DESCRIPTION
Fixes #47 - parseInt and parseFloat should return NaN instead of 0 for invalid numbers.
