### PR TITLE
Add lifecycle setup/teardown methods to test suite

### DIFF
--- a/test/cultures.js
+++ b/test/cultures.js
@@ -1,4 +1,4 @@
-module( "cultures", {} );
+module( "cultures", lifecycle );
 
 test("Culture name property and key", function() {
 	var name,

--- a/test/findClosestCulture.js
+++ b/test/findClosestCulture.js
@@ -1,18 +1,10 @@
 (function() {
 
-var allCultures, de, deDE, en;
+module("findClosestCulture", lifecycle );
 
-module("findClosestCulture", {
-  setup: function() {
-    allCultures = Globalize.cultures;
-		en = Globalize.cultures.en;
-		de = Globalize.cultures.de;
-		deDE = Globalize.cultures["de-DE"];
-  },
-  teardown: function() {
-    Globalize.cultures = allCultures;
-  }
-});
+var en = originalCultures( "en" ),
+	de = originalCultures( "de" ),
+	deDE = originalCultures( "de-DE" );
 
 test("default should be en", function() {
 	// use QUnit.equiv to avoid page-long printing

--- a/test/format.js
+++ b/test/format.js
@@ -1,4 +1,4 @@
-module( "format", {} );
+module( "format", lifecycle );
 
 test("Number Formatting - n for number", function() {
 	equal( Globalize.format(123.45, "n"), "123.45" );

--- a/test/index.html
+++ b/test/index.html
@@ -7,6 +7,7 @@
 		<script src="../lib/globalize.js"></script>
 		<script src="../lib/cultures/globalize.cultures.js"></script>
 		<script src="qunit/qunit.js"></script>
+		<script src="testsuite.js"></script>
 		<script src="cultures.js"></script>
 		<script src="instance.js"></script>
 		<script src="findClosestCulture.js"></script>

--- a/test/instance.js
+++ b/test/instance.js
@@ -1,4 +1,4 @@
-module("instance");
+module("instance", lifecycle );
 
 test("constructor sets culture", function() {
 	var globalizeDe = Globalize("de");

--- a/test/localize.js
+++ b/test/localize.js
@@ -1,4 +1,4 @@
-module( "localize", {} );
+module( "localize", lifecycle );
 
 test('set and retrieve translations', function() {
 	Globalize.addCultureInfo("fr", {
@@ -21,27 +21,27 @@ test('retrieve translations with new culture', function() {
 });
 
 test('Retrieve translations for the most appropriate culture', function() {
-  Globalize.addCultureInfo("default", {
-    messages: {
-      "hello": "hello",
-      "world": "world"
-    }
-  });
+	Globalize.addCultureInfo("default", {
+		messages: {
+			"hello": "hello",
+			"world": "world"
+		}
+	});
 
-  Globalize.addCultureInfo("es", {
-    messages: {
-      "world": "mundo"
-    }
-  });
+	Globalize.addCultureInfo("es", {
+		messages: {
+			"world": "mundo"
+		}
+	});
 
-  Globalize.culture("es");
+	Globalize.culture("es");
 
-  strictEqual( Globalize.localize("world"), "mundo", "Key exists in current culture 'es'");
-  strictEqual( Globalize.localize("world", "es"), "mundo", "Key exists in specified culture");
-  strictEqual( Globalize.localize("world", "fr"), "world",
-    "Key does not exist in specified culture but does exist in default culture");
-  strictEqual( Globalize.localize("hello"), "hello",
-    "Key does not exist in current culture, but does exist in default culture");
-  strictEqual( Globalize.localize("goodbye"), undefined,
-    "Key does not exist in current culture or default culture");
+	strictEqual( Globalize.localize("world"), "mundo", "Key exists in current culture 'es'");
+	strictEqual( Globalize.localize("world", "es"), "mundo", "Key exists in specified culture");
+	strictEqual( Globalize.localize("world", "fr"), "world",
+		"Key does not exist in specified culture but does exist in default culture");
+	strictEqual( Globalize.localize("hello"), "hello",
+		"Key does not exist in current culture, but does exist in default culture");
+	strictEqual( Globalize.localize("goodbye"), undefined,
+		"Key does not exist in current culture or default culture");
 });

--- a/test/parse.js
+++ b/test/parse.js
@@ -1,8 +1,4 @@
-module("parseFloat", {
-	setup: function() {
-		Globalize.culture( "default" );
-	}
-});
+module("parseFloat", lifecycle );
 
 test("basics, float", function() {
 	equal( Globalize.parseFloat("5.51"), 5.51 );

--- a/test/testsuite.js
+++ b/test/testsuite.js
@@ -1,0 +1,19 @@
+// Test suite helper methods
+(function( window, undefined ) {
+	var cultures = Globalize.cultures;
+
+	window.lifecycle = {
+		setup: function() {
+			cultures = Globalize.cultures;
+			Globalize.culture( "default" );
+		},
+		teardown: function() {
+			Globalize.cultures = cultures;
+		}
+	};
+
+	window.originalCultures = function( culture ) {
+		return culture ? cultures[ culture ] : cultures;
+	};
+
+})( this );


### PR DESCRIPTION
This ensures that every test beings with the default culture selected
and the original culture definitions intact. Introduces two global
variables: (1) lifecycle, which is an object containing the setup and
teardown functions for use in Qunit.module and (2) originalCultures,
which is a method that will return an unmodified version of a specific
culture definition (if an string argument is given) or all culture
definitions if called with no argument.
