### PR TITLE
only pad if necessary

### DIFF
--- a/lib/globalize.js
+++ b/lib/globalize.js
@@ -688,7 +688,7 @@ formatDate = function( value, format, culture ) {
 (function() {
 	var expandNumber;
 
-	expandNumber = function( number, precision, formatInfo ) {
+	expandNumber = function( number, precision, formatInfo, pad ) {
 		var groupSizes = formatInfo.groupSizes,
 			curSize = groupSizes[ 0 ],
 			curGroupIndex = 1,
@@ -723,8 +723,12 @@ formatDate = function( value, format, culture ) {
 		}
 
 		if ( precision > 0 ) {
-			right = formatInfo[ "." ] +
-				( (right.length > precision) ? right.slice(0, precision) : zeroPad(right, precision) );
+			if (right.length > precision)
+				right = formatInfo['.'] + right.slice(0, precision)
+			else if (pad)
+				right = formatInfo['.'] + zeroPad(right, precision)
+			else if (right.length > 0)
+				right = formatInfo['.'] + right
 		}
 		else {
 			right = "";
@@ -793,8 +797,12 @@ formatDate = function( value, format, culture ) {
 			case "P":
 				formatInfo = formatInfo || nf.percent;
 				pattern = value < 0 ? formatInfo.pattern[ 0 ] : ( formatInfo.pattern[1] || "n" );
-				if ( precision === -1 ) precision = formatInfo.decimals;
-				number = expandNumber( number * (current === "P" ? 100 : 1), precision, formatInfo );
+				pad = false;
+				if ( precision === -1 ) 
+					precision = formatInfo.decimals;
+				else
+					pad = true;
+				number = expandNumber( number * (current === "P" ? 100 : 1), precision, formatInfo, pad || current === "C" );
 				break;
 			default:
 				throw "Bad number format specifier: " + current;

--- a/test/format.js
+++ b/test/format.js
@@ -2,8 +2,12 @@ module( "format", lifecycle );
 
 test("Number Formatting - n for number", function() {
 	equal( Globalize.format(123.45, "n"), "123.45" );
+
+	equal( Globalize.format(123.4, "n"), "123.4" );
 	equal( Globalize.format(123.45, "n0"), "123" );
 	equal( Globalize.format(123.45, "n1"), "123.5" );
+	equal( Globalize.format(123.45, "n4"), "123.4500" );
+	equal( Globalize.format(123.4, "n2"), "123.40" );
 });
 
 test("Number Formatting - d for decimal", function() {
@@ -18,12 +22,16 @@ test("Number Formatting - c for currency", function() {
 	equal( Globalize.format(123.45, "c"), "$123.45" );
 	equal( Globalize.format(123.45, "c0"), "$123" );
 	equal( Globalize.format(123.45, "c1"), "$123.5" );
+	equal( Globalize.format(123.45, "c2"), "$123.45" );
+	equal( Globalize.format(123.45, "c4"), "$123.4500" );
 	equal( Globalize.format(-123.45, "c"), "($123.45)" );
 });
 
 test("Number Formatting - p for percentage", function() {
 	equal( Globalize.format(0.12345, "p"), "12.35 %" );
+	equal( Globalize.format(0.12, "p"), "12 %" );
 	equal( Globalize.format(0.12345, "p0"), "12 %" );
+	equal( Globalize.format(0.12345, "p2"), "12.35 %" );
 	equal( Globalize.format(0.12345, "p4"), "12.3450 %" );
 });
 


### PR DESCRIPTION
The number 1 should not be formatted to 1.00 unless it was explicitly requested by adding a precision to the format specifier.
