### PR TITLE
Don't expose culture as a JavaScript global variable

### DIFF
--- a/lib/globalize.js
+++ b/lib/globalize.js
@@ -1412,7 +1412,7 @@ Globalize.findClosestCulture = function( name ) {
 };
 
 Globalize.format = function( value, format, cultureSelector ) {
-	culture = this.findClosestCulture( cultureSelector );
+	var culture = this.findClosestCulture( cultureSelector );
 	if ( value instanceof Date ) {
 		value = formatDate( value, format, culture );
 	}


### PR DESCRIPTION
We currently expose the variable `culture` as a global JavaScript variable.
This could possibly cause errors when you use the plug-in with other plug-ins or other JavaScript code.
