### PR TITLE
Fix for Polish and Polish (Poland) cultures standard calendar

### DIFF
--- a/lib/cultures/globalize.culture.pl-PL.js
+++ b/lib/cultures/globalize.culture.pl-PL.js
@@ -50,7 +50,7 @@ Globalize.addCultureInfo( "pl-PL", "default", {
 	},
 	calendars: {
 		standard: {
-			"/": "-",
+			"/": ".",
 			firstDay: 1,
 			days: {
 				names: ["niedziela","poniedziałek","wtorek","środa","czwartek","piątek","sobota"],
@@ -67,13 +67,14 @@ Globalize.addCultureInfo( "pl-PL", "default", {
 			},
 			AM: null,
 			PM: null,
+			eras: [{"name":"n.e.","start":null,"offset":0}],
 			patterns: {
-				d: "yyyy-MM-dd",
-				D: "d MMMM yyyy",
+				d: "dd.MM.yyyy",
+				D: "dddd, d MMMM yyyy",
 				t: "HH:mm",
 				T: "HH:mm:ss",
-				f: "d MMMM yyyy HH:mm",
-				F: "d MMMM yyyy HH:mm:ss",
+				f: "dddd, d MMMM yyyy HH:mm",
+				F: "dddd, d MMMM yyyy HH:mm:ss",
 				M: "d MMMM",
 				Y: "MMMM yyyy"
 			}

--- a/lib/cultures/globalize.culture.pl.js
+++ b/lib/cultures/globalize.culture.pl.js
@@ -50,7 +50,7 @@ Globalize.addCultureInfo( "pl", "default", {
 	},
 	calendars: {
 		standard: {
-			"/": "-",
+			"/": ".",
 			firstDay: 1,
 			days: {
 				names: ["niedziela","poniedziałek","wtorek","środa","czwartek","piątek","sobota"],
@@ -67,13 +67,14 @@ Globalize.addCultureInfo( "pl", "default", {
 			},
 			AM: null,
 			PM: null,
+			eras: [{"name":"n.e.","start":null,"offset":0}],
 			patterns: {
-				d: "yyyy-MM-dd",
-				D: "d MMMM yyyy",
+				d: "dd.MM.yyyy",
+				D: "dddd, d MMMM yyyy",
 				t: "HH:mm",
 				T: "HH:mm:ss",
-				f: "d MMMM yyyy HH:mm",
-				F: "d MMMM yyyy HH:mm:ss",
+				f: "dddd, d MMMM yyyy HH:mm",
+				F: "dddd, d MMMM yyyy HH:mm:ss",
 				M: "d MMMM",
 				Y: "MMMM yyyy"
 			}


### PR DESCRIPTION
Fix for Polish and Polish (Poland) cultures standard calendar:
- separator of parts of date
- eras
- short date pattern
- long date pattern
- long date, short time pattern
- long date, long time pattern

All changes are in line with [CLDR v21.0.1](http://cldr.unicode.org/index) from The Unicode Consortium.
