### PR TITLE
Fixes #57 - Timezone formatting needs to be localized

### DIFF
--- a/lib/globalize.js
+++ b/lib/globalize.js
@@ -448,6 +448,7 @@ expandFormat = function( cal, format ) {
 formatDate = function( value, format, culture ) {
 	var cal = culture.calendar,
 		convert = cal.convert,
+		nf = culture.numberFormat,
 		ret;
 
 	if ( !format || !format.length || format === "i" ) {
@@ -655,17 +656,15 @@ formatDate = function( value, format, culture ) {
 				// Time zone offset with leading zero
 				hour = value.getTimezoneOffset() / 60;
 				ret.push(
-					( hour <= 0 ? "+" : "-" ) + padZeros( Math.floor(Math.abs(hour)), clength )
+					( hour <= 0 ? nf[ "+" ] : nf[ "-" ] ) + padZeros( Math.floor(Math.abs(hour)), clength )
 				);
 				break;
 			case "zzz":
 				// Time zone offset with leading zero
 				hour = value.getTimezoneOffset() / 60;
 				ret.push(
-					( hour <= 0 ? "+" : "-" ) + padZeros( Math.floor(Math.abs(hour)), 2 ) +
-					// Hard coded ":" separator, rather than using cal.TimeSeparator
-					// Repeated here for consistency, plus ":" was already assumed in date parsing.
-					":" + padZeros( Math.abs(value.getTimezoneOffset() % 60), 2 )
+					( hour <= 0 ? nf[ "+" ] : nf[ "-" ] ) + padZeros( Math.floor(Math.abs(hour)), 2 )
+					+ cal[ ":" ] + padZeros( Math.abs(value.getTimezoneOffset() % 60), 2 )
 				);
 				break;
 			case "g":

--- a/test/format.js
+++ b/test/format.js
@@ -1,5 +1,48 @@
 module( "format", lifecycle );
 
+// #57 Timezone offset formatting
+test("Date Formatting - zz/zzz for timezone offset", function() {
+	function checkDateFormat( culture, format ) {
+		culture = Globalize.culture( culture );
+
+		var rFormat = new RegExp(
+			"(\\" + culture.numberFormat[ "-" ] + "\\d{2})" +
+			"(\\" + culture.calendar[ ":" ] + "\\d{2})?"
+		);
+
+		var matches = Globalize
+			.format( new Date(), format, culture )
+			.match( rFormat );
+
+		switch( format ) {
+			case "zz": {
+				return !!matches[ 1 ];
+			} break;
+			case "zzz": {
+				return !!matches[ 2 ];
+			} break;
+		}
+
+		return false;
+	}
+
+	Globalize.cultures[ "test" ] = {
+		calendar: {
+			":" : "."
+		},
+		numberFormat: {
+			"-" : "\u2212"
+		}
+	};
+
+	ok( checkDateFormat( "test", "zz" ) );
+	ok( checkDateFormat( "test", "zzz" ) );
+
+	// "bn" culture uses "." for ":"
+	ok( checkDateFormat( "bn", "zz" ) );
+	ok( checkDateFormat( "bn", "zzz" ) );
+});
+
 test("Number Formatting - n for number", function() {
 	equal( Globalize.format(123.45, "n"), "123.45" );
 	equal( Globalize.format(123.45, "n0"), "123" );


### PR DESCRIPTION
See: https://github.com/jquery/globalize/issues/57 and https://github.com/jquery/globalize/pull/61

One note: I kept cal.TimeSeparator in there as I believe it is correct behavior and the tests will fail otherwise.
