### PR TITLE
I was getting error here as the variable was a number, hence no need to ...

### DIFF
--- a/lib/globalize.js
+++ b/lib/globalize.js
@@ -1479,7 +1479,7 @@ Globalize.parseFloat = function( value, radix, cultureSelector ) {
 	var ret = NaN,
 		nf = culture.numberFormat;
 
-	if ( value.indexOf(culture.numberFormat.currency.symbol) > -1 ) {
+	if ( isNaN(value) && value.indexOf(culture.numberFormat.currency.symbol) > -1 ) {
 		// remove currency symbol
 		value = value.replace( culture.numberFormat.currency.symbol, "" );
 		// replace decimal seperator


### PR DESCRIPTION
...check for currency symbols, nor indexOf exists. Was using the nuget package 0.1.0 when testing; so this might be avoided in other part of code.
