### PR TITLE
Parsing Percentages #69

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,9 @@ default.
 Parses a string representing a whole number in the given radix (10 by default),
 taking into account any formatting rules followed by the given culture (or the
 current culture, if not specified).
+
+If a percentage is passed into parseInt, the percent sign will be removed and the number parsed as is.
+Example: 12.34% would be returned as 12.
 <pre>
 // assuming a culture where "," is the group separator
 // and "." is the decimal separator
@@ -228,6 +231,9 @@ Globalize.parseInt( "1.234,56" ); // 1234
 Parses a string representing a floating point number in the given radix (10 by
 default), taking into account any formatting rules followed by the given
 culture (or the current culture, if not specified).
+
+If a percentage is passed into parseFloat, the percent sign will be removed and the number parsed as is.
+Example: 12.34% would be returned as 12.34
 <pre>
 // assuming a culture where "," is the group separator
 // and "." is the decimal separator

--- a/lib/globalize.js
+++ b/lib/globalize.js
@@ -1486,6 +1486,11 @@ Globalize.parseFloat = function( value, radix, cultureSelector ) {
 		value = value.replace( culture.numberFormat.currency["."], culture.numberFormat["."] );
 	}
 
+	//Remove percentage character from number string before parsing
+	if ( value.indexOf(culture.numberFormat.percent.symbol) > -1){
+		value = value.replace( culture.numberFormat.percent.symbol, "" );
+	}
+
 	// remove spaces: leading, trailing and between - and number. Used for negative currency pt-BR
 	value = value.replace( / /g, "" );
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -14,6 +14,15 @@ test("basics, int", function() {
 	equal( Globalize.parseInt("-5000000000"), -5000000000 );
 });
 
+test( "basic, percentage", function() {
+	equal( Globalize.parseInt( "12%" ), "12" );
+	equal( Globalize.parseInt( "12.34%" ), "12" );
+	equal( Globalize.parseInt( "-12.34%" ), "-12" );
+	equal( Globalize.parseFloat( "12%" ), "12" );
+	equal( Globalize.parseFloat( "12.34%" ), "12.34" );
+	equal( Globalize.parseFloat( "-12.34%" ), "-12.34" );
+});
+
 test("basics, currency", function() {
 	equal( Globalize.parseInt("$5.51"), 5 );
 	equal( Globalize.parseFloat("$5.51"), 5.51 );


### PR DESCRIPTION
Added logic to strip percent symbol. Update documentation and test cases. Fixed #69: parseInt/parseFloat don't work for percentages
