### PR TITLE
Add loadCulture method

### DIFF
--- a/lib/globalize.js
+++ b/lib/globalize.js
@@ -1583,4 +1583,10 @@ Globalize.culture = function( cultureSelector ) {
 	return this.findClosestCulture( cultureSelector ) || this.cultures[ "default" ];
 };
 
+if ( typeof require !== "undefined" ) {
+	Globalize.loadCulture = function( cultureName ) {
+		require( "./cultures/globalize.culture." + cultureName + ".js" );
+	};
+}
+
 }( this ));


### PR DESCRIPTION
Adds a `loadCulture` method for loading cultures in a node.js environment. Fixes #132
