### PR TITLE
Add default date format 's': short sortable.

### DIFF
--- a/lib/globalize.js
+++ b/lib/globalize.js
@@ -234,6 +234,8 @@ Globalize.cultures[ "default" ] = {
 				M: "MMMM dd",
 				// month/year pattern
 				Y: "yyyy MMMM",
+				// s is a short sortable format that does not vary by culture
+				s: "yyyy\u0027-\u0027MM\u0027-\u0027dd"
 				// S is a sortable format that does not vary by culture
 				S: "yyyy\u0027-\u0027MM\u0027-\u0027dd\u0027T\u0027HH\u0027:\u0027mm\u0027:\u0027ss"
 			}


### PR DESCRIPTION
Only date in ISO 8601 format.
