### PR TITLE
Expose parseDate() on the instance

### DIFF
--- a/lib/globalize.js
+++ b/lib/globalize.js
@@ -1287,6 +1287,10 @@ Globalize.prototype.parseFloat = function( value, radix, cultureSelector ) {
 	return Globalize.parseFloat.call( this, value, radix, cultureSelector );
 };
 
+Globalize.prototype.parseDate = function( value, formats, cultureSelector){
+	return Globalize.parseDate.call( this, value, formats, cultureSelector );
+};
+
 Globalize.prototype.culture = function( cultureSelector ) {
 	return Globalize.culture.call( this, cultureSelector );
 };

--- a/test/instance.js
+++ b/test/instance.js
@@ -11,3 +11,8 @@ test("constructor sets culture", function() {
 	equal( globalizeDe.parseFloat("5.3", "en"), 5.3 );
 	equal( globalizeDe.parseFloat("5,3", "en"), 53 );
 });
+
+test("parseDate is accessible from the instance", function () {
+	var g = Globalize('de-CH');
+	equal( g.parseDate('25.02.2013').valueOf(), Globalize.parseDate('25.02.2013', null, 'de-CH').valueOf() );
+});


### PR DESCRIPTION
parseInt and parseFloat are already accessible from the globalize
instance, let's add parseDate too.
