### PR TITLE
Ensure that value is a string, before parsing

### DIFF
--- a/lib/globalize.js
+++ b/lib/globalize.js
@@ -1470,7 +1470,7 @@ Globalize.parseInt = function( value, radix, cultureSelector ) {
 
 Globalize.parseFloat = function( value, radix, cultureSelector ) {
 	// ensure that value is a string to prevent errors
-	value = String.prototype.toString.call(value);
+	value = value.toString();
 
 	// radix argument is optional
 	if ( typeof radix !== "number" ) {


### PR DESCRIPTION
Need to ensure that value is a string, because if not then will thrown exception "value.indexOf is not a function".
