### PR TITLE
Update globalize.culture.fr-CA.js

### DIFF
--- a/lib/cultures/globalize.culture.fr-CA.js
+++ b/lib/cultures/globalize.culture.fr-CA.js
@@ -31,18 +31,18 @@ Globalize.addCultureInfo( "fr-CA", "default", {
 	nativeName: "français (Canada)",
 	language: "fr",
 	numberFormat: {
-		",": " ",
+		",": " ",
 		".": ",",
 		"NaN": "Non Numérique",
 		negativeInfinity: "-Infini",
 		positiveInfinity: "+Infini",
 		percent: {
-			",": " ",
+			",": " ",
 			".": ","
 		},
 		currency: {
 			pattern: ["(n $)","n $"],
-			",": " ",
+			",": " ",
 			".": ","
 		}
 	},


### PR DESCRIPTION
The previous symbol for thousand separator prints Â just before the space.
