### PR TITLE
Update globalize.js

### DIFF
--- a/lib/globalize.js
+++ b/lib/globalize.js
@@ -694,8 +694,7 @@ formatDate = function( value, format, culture ) {
 		var groupSizes = formatInfo.groupSizes,
 			curSize = groupSizes[ 0 ],
 			curGroupIndex = 1,
-			factor = Math.pow( 10, precision ),
-			rounded = Math.round( number * factor ) / factor;
+			rounded = (typeof number === "number" ? number.toFixed(precision) : NaN);
 
 		if ( !isFinite(rounded) ) {
 			rounded = number;


### PR DESCRIPTION
The old way of rounding with Math.round does not work properly. Here is an example:

number = 10.16345
precision = 4

Expected result = 10.1635
Actual result = 10.1634

Thus I propose a solution where toFixed-method is used instead of Math.pow and Math.round!
