### PR TITLE
Tests: Namespacing QUnit globals

### DIFF
--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -14,12 +14,8 @@
 	"unused": true,
 
 	"globals": {
-		"deepEqual": false,
 		"define": false,
-		"equal": false,
-		"module": false,
-		"QUnit": false,
 		"require": false,
-		"test": false
+		"QUnit": false
 	}
 }

--- a/test/functional/date/format.js
+++ b/test/functional/date/format.js
@@ -17,42 +17,42 @@ Globalize.load( timeData );
 Globalize.load( weekData );
 Globalize.locale( "en" );
 
-module( "Datetime Format" );
+QUnit.module( "Datetime Format" );
 
-test( "should format skeleton", function() {
-	equal( Globalize.formatDate( date, { skeleton: "d" } ), "15" );
-	equal( Globalize.formatDate( date, { skeleton: "Ed" } ), "15 Wed" );
-	equal( Globalize.formatDate( date, { skeleton: "Ehms" } ), "Wed 5:35:07 PM" );
-	equal( Globalize.formatDate( date, { skeleton: "GyMMMEd" } ), "Wed, Sep 15, 2010 AD" );
-	equal( Globalize.formatDate( date, { skeleton: "yMd" } ), "9/15/2010" );
-	equal( Globalize.formatDate( date, { skeleton: "yQQQ" } ), "Q3 2010" );
+QUnit.test( "should format skeleton", function( assert ) {
+	assert.equal( Globalize.formatDate( date, { skeleton: "d" } ), "15" );
+	assert.equal( Globalize.formatDate( date, { skeleton: "Ed" } ), "15 Wed" );
+	assert.equal( Globalize.formatDate( date, { skeleton: "Ehms" } ), "Wed 5:35:07 PM" );
+	assert.equal( Globalize.formatDate( date, { skeleton: "GyMMMEd" } ), "Wed, Sep 15, 2010 AD" );
+	assert.equal( Globalize.formatDate( date, { skeleton: "yMd" } ), "9/15/2010" );
+	assert.equal( Globalize.formatDate( date, { skeleton: "yQQQ" } ), "Q3 2010" );
 
 	// Passed as string
-	equal( Globalize.formatDate( date, "GyMMMEd" ), "Wed, Sep 15, 2010 AD" );
+	assert.equal( Globalize.formatDate( date, "GyMMMEd" ), "Wed, Sep 15, 2010 AD" );
 
 	// Via instance .formatDate().
-	equal( Globalize( "pt" ).formatDate( date, { skeleton: "Ehms" } ), "qua, 5:35:07 PM" );
-	equal( Globalize( "pt" ).formatDate( date, { skeleton: "GyMMMEd" } ), "qua, 15 'de' set 'de' 2010 d.C." );
+	assert.equal( Globalize( "pt" ).formatDate( date, { skeleton: "Ehms" } ), "qua, 5:35:07 PM" );
+	assert.equal( Globalize( "pt" ).formatDate( date, { skeleton: "GyMMMEd" } ), "qua, 15 'de' set 'de' 2010 d.C." );
 });
 
-test( "should format time presets", function() {
-	equal( Globalize.formatDate( date, { time: "medium" } ), "5:35:07 PM" );
-	equal( Globalize.formatDate( date, { time: "short" } ), "5:35 PM" );
+QUnit.test( "should format time presets", function( assert ) {
+	assert.equal( Globalize.formatDate( date, { time: "medium" } ), "5:35:07 PM" );
+	assert.equal( Globalize.formatDate( date, { time: "short" } ), "5:35 PM" );
 });
 
-test( "should format date presets", function() {
-	equal( Globalize.formatDate( date, { date: "full" } ), "Wednesday, September 15, 2010" );
-	equal( Globalize.formatDate( date, { date: "long" } ), "September 15, 2010" );
-	equal( Globalize.formatDate( date, { date: "medium" } ), "Sep 15, 2010" );
-	equal( Globalize.formatDate( date, { date: "short" } ), "9/15/10" );
+QUnit.test( "should format date presets", function( assert ) {
+	assert.equal( Globalize.formatDate( date, { date: "full" } ), "Wednesday, September 15, 2010" );
+	assert.equal( Globalize.formatDate( date, { date: "long" } ), "September 15, 2010" );
+	assert.equal( Globalize.formatDate( date, { date: "medium" } ), "Sep 15, 2010" );
+	assert.equal( Globalize.formatDate( date, { date: "short" } ), "9/15/10" );
 });
 
-test( "should format datetime presets", function() {
-	equal( Globalize.formatDate( date, { datetime: "medium" } ), "Sep 15, 2010, 5:35:07 PM" );
+QUnit.test( "should format datetime presets", function( assert ) {
+	assert.equal( Globalize.formatDate( date, { datetime: "medium" } ), "Sep 15, 2010, 5:35:07 PM" );
 });
 
-test( "should format raw patterns", function() {
-	equal( Globalize.formatDate( date, { pattern: "E, MMM d, y G" } ), "Wed, Sep 15, 2010 AD" );
+QUnit.test( "should format raw patterns", function( assert ) {
+	assert.equal( Globalize.formatDate( date, { pattern: "E, MMM d, y G" } ), "Wed, Sep 15, 2010 AD" );
 });
 
 });

--- a/test/functional/date/parse.js
+++ b/test/functional/date/parse.js
@@ -18,79 +18,79 @@ Globalize.load( timeData );
 Globalize.load( weekData );
 Globalize.locale( "en" );
 
-module( "Datetime Parse" );
+QUnit.module( "Datetime Parse" );
 
-function assertParseDate( input, options, output ) {
-	deepEqual( Globalize.parseDate( input, options ), output, JSON.stringify( options ) );
+function assertParseDate( assert, input, options, output ) {
+	assert.deepEqual( Globalize.parseDate( input, options ), output, JSON.stringify( options ) );
 }
 
-test( "should parse skeleton", function() {
+QUnit.test( "should parse skeleton", function( assert ) {
 	date = new Date();
 	date.setDate( 15 );
 	date = startOf( date, "day" );
-	assertParseDate( "15", { skeleton: "d" }, date );
-	assertParseDate( "15 Wed", { skeleton: "Ed" }, date );
+	assertParseDate( assert, "15", { skeleton: "d" }, date );
+	assertParseDate( assert, "15 Wed", { skeleton: "Ed" }, date );
 
 	date = new Date();
 	date.setHours( 17 );
 	date.setMinutes( 35 );
 	date.setSeconds( 7 );
 	date = startOf( date, "second" );
-	assertParseDate( "Wed 5:35:07 PM", { skeleton: "Ehms" }, date );
+	assertParseDate( assert, "Wed 5:35:07 PM", { skeleton: "Ehms" }, date );
 
 	date = new Date( 2010, 8, 15 );
 	date = startOf( date, "day" );
-	assertParseDate( "Wed, Sep 15, 2010 AD", { skeleton: "GyMMMEd" }, date );
-	assertParseDate( "9/15/2010", { skeleton: "yMd" }, date );
+	assertParseDate( assert, "Wed, Sep 15, 2010 AD", { skeleton: "GyMMMEd" }, date );
+	assertParseDate( assert, "9/15/2010", { skeleton: "yMd" }, date );
 
 	date = new Date( 2010, 0 );
 	date = startOf( date, "year" );
-	assertParseDate( "Q3 2010", { skeleton: "yQQQ" }, date );
+	assertParseDate( assert, "Q3 2010", { skeleton: "yQQQ" }, date );
 
 	// Via instance globalize.parseDate().
-	deepEqual( Globalize( "pt" ).parseDate( "2010 T3", { skeleton: "yQQQ" } ), date, "{ skeleton: \"yQQQ\" }" );
+	assert.deepEqual( Globalize( "pt" ).parseDate( "2010 T3", { skeleton: "yQQQ" } ), date, "{ skeleton: \"yQQQ\" }" );
 });
 
-test( "should parse time presets", function() {
+QUnit.test( "should parse time presets", function( assert ) {
 	date = new Date();
 	date.setHours( 17 );
 	date.setMinutes( 35 );
 	date.setSeconds( 7 );
 	date = startOf( date, "second" );
-	assertParseDate( "5:35:07 PM", { time: "medium" }, date );
+	assertParseDate( assert, "5:35:07 PM", { time: "medium" }, date );
 	date = startOf( date, "minute" );
-	assertParseDate( "5:35 PM", { time: "short" }, date );
+	assertParseDate( assert, "5:35 PM", { time: "short" }, date );
 });
 
-test( "should parse date presets", function() {
+QUnit.test( "should parse date presets", function( assert ) {
 	date = new Date( 2010, 8, 15 );
 	date = startOf( date, "day" );
-	assertParseDate( "Wednesday, September 15, 2010", { date: "full" }, date );
-	assertParseDate( "September 15, 2010", { date: "long" }, date );
-	assertParseDate( "Sep 15, 2010", { date: "medium" }, date );
-	assertParseDate( "9/15/10", { date: "short" }, date );
+	assertParseDate( assert, "Wednesday, September 15, 2010", { date: "full" }, date );
+	assertParseDate( assert, "September 15, 2010", { date: "long" }, date );
+	assertParseDate( assert, "Sep 15, 2010", { date: "medium" }, date );
+	assertParseDate( assert, "9/15/10", { date: "short" }, date );
 });
 
-test( "should parse datetime presets", function() {
+QUnit.test( "should parse datetime presets", function( assert ) {
 	date = new Date( 2010, 8, 15 );
 	date = startOf( date, "day" );
-	assertParseDate( "Wednesday, September 15, 2010", { date: "full" }, date );
+	assertParseDate( assert, "Wednesday, September 15, 2010", { date: "full" }, date );
 
 	date = new Date( 2010, 8, 15, 17, 35, 7 );
 	date = startOf( date, "second" );
-	assertParseDate( "Sep 15, 2010, 5:35:07 PM", { datetime: "medium" }, date );
+	assertParseDate( assert, "Sep 15, 2010, 5:35:07 PM", { datetime: "medium" }, date );
 });
 
-test( "should parse raw patterns", function() {
+QUnit.test( "should parse raw patterns", function( assert ) {
 	date = new Date( 2010, 8, 15 );
 	date = startOf( date, "day" );
-	assertParseDate( "Wed, Sep 15, 2010 AD", { pattern: "E, MMM d, y G" }, date );
+	assertParseDate( assert, "Wed, Sep 15, 2010 AD", { pattern: "E, MMM d, y G" }, date );
 });
 
-test( "should parse a formatted date (reverse operation test)", function() {
+QUnit.test( "should parse a formatted date (reverse operation test)", function( assert ) {
 	date = new Date();
 	date = startOf( date, "minute" );
-	deepEqual( Globalize.parseDate( Globalize.formatDate( date, { datetime: "short" } ), { datetime: "short" } ), date );
+	assert.deepEqual( Globalize.parseDate( Globalize.formatDate( date, { datetime: "short" } ), { datetime: "short" } ), date );
 });
 
 });

--- a/test/functional/number/format.js
+++ b/test/functional/number/format.js
@@ -15,46 +15,46 @@ Globalize.load( esNumbers );
 Globalize.load( likelySubtags );
 Globalize.locale( "en" );
 
-module( "Number Format" );
+QUnit.module( "Number Format" );
 
-test( "should format decimal style", function() {
-	equal( Globalize.formatNumber( pi ), "3.142" );
-	equal( Globalize( "es" ).formatNumber( pi ), "3,142" );
-	equal( Globalize( "ar" ).formatNumber( pi ), "3٫142" );
-	equal( Globalize.formatNumber( 99999999.99 ), "99,999,999.99" );
+QUnit.test( "should format decimal style", function( assert ) {
+	assert.equal( Globalize.formatNumber( pi ), "3.142" );
+	assert.equal( Globalize( "es" ).formatNumber( pi ), "3,142" );
+	assert.equal( Globalize( "ar" ).formatNumber( pi ), "3٫142" );
+	assert.equal( Globalize.formatNumber( 99999999.99 ), "99,999,999.99" );
 
-	equal( Globalize.formatNumber( pi, {
+	assert.equal( Globalize.formatNumber( pi, {
 		minimumIntegerDigits: 2,
 		minimumFractionDigits: 2,
 		maximumFractionDigits: 2
 	}), "03.14" );
 
-	equal( Globalize.formatNumber( pi, {
+	assert.equal( Globalize.formatNumber( pi, {
 		minimumSignificantDigits: 1,
 		maximumSignificantDigits: 3
 	}), "3.14" );
 
-	equal( Globalize.formatNumber( 12345, {
+	assert.equal( Globalize.formatNumber( 12345, {
 		minimumSignificantDigits: 1,
 		maximumSignificantDigits: 3
 	}), "12,300" );
 
-	equal( Globalize.formatNumber( 0.00012345, {
+	assert.equal( Globalize.formatNumber( 0.00012345, {
 		minimumSignificantDigits: 1,
 		maximumSignificantDigits: 3
 	}), "0.000123" );
 
-	equal( Globalize.formatNumber( 0.00010001, {
+	assert.equal( Globalize.formatNumber( 0.00010001, {
 		minimumSignificantDigits: 1,
 		maximumSignificantDigits: 3
 	}), "0.0001" );
 
-	equal( Globalize.formatNumber( 99999999.99, { useGrouping: false } ), "99999999.99" );
+	assert.equal( Globalize.formatNumber( 99999999.99, { useGrouping: false } ), "99999999.99" );
 });
 
-test( "should format percent style", function() {
-	equal( Globalize.formatNumber( pi, { style: "percent" } ), "314%" );
-	equal( Globalize( "ar" ).formatNumber( pi, { style: "percent" } ), "314٪" );
+QUnit.test( "should format percent style", function( assert ) {
+	assert.equal( Globalize.formatNumber( pi, { style: "percent" } ), "314%" );
+	assert.equal( Globalize( "ar" ).formatNumber( pi, { style: "percent" } ), "314٪" );
 });
 
 });

--- a/test/functional/number/parse.js
+++ b/test/functional/number/parse.js
@@ -24,81 +24,81 @@ es = new Globalize( "es" );
 sv = new Globalize( "sv" );
 Globalize.locale( "en" );
 
-module( "Number Parse" );
+QUnit.module( "Number Parse" );
 
 /**
  *  Integers
  */
 
-test( "should parse integers", function() {
-	equal( Globalize.parseNumber( "3" ), 3 );
-	equal( Globalize.parseNumber( "12,735" ), 12735 );
-	equal( Globalize.parseNumber( "1,2,7,35" ), 12735 );
-	equal( es.parseNumber( "12.735" ), 12735 );
+QUnit.test( "should parse integers", function( assert ) {
+	assert.equal( Globalize.parseNumber( "3" ), 3 );
+	assert.equal( Globalize.parseNumber( "12,735" ), 12735 );
+	assert.equal( Globalize.parseNumber( "1,2,7,35" ), 12735 );
+	assert.equal( es.parseNumber( "12.735" ), 12735 );
 });
 
-test( "should parse negative integers", function() {
-	equal( Globalize.parseNumber( "-3" ), -3 );
-	equal( Globalize.parseNumber( "-12,735" ), -12735 );
+QUnit.test( "should parse negative integers", function( assert ) {
+	assert.equal( Globalize.parseNumber( "-3" ), -3 );
+	assert.equal( Globalize.parseNumber( "-12,735" ), -12735 );
 });
 
 /**
  *  Decimals
  */
 
-test( "should parse decimals", function() {
-	equal( Globalize.parseNumber( "3.14" ), 3.14 );
-	equal( es.parseNumber( "3,14" ), 3.14 );
-	equal( ar.parseNumber( "3٫14" ), 3.14 );
-	equal( Globalize.parseNumber( "3.00" ), 3 );
-	equal( Globalize.parseNumber( "12735.0" ), 12735 );
-	equal( Globalize.parseNumber( "0.10" ), 0.1 );
+QUnit.test( "should parse decimals", function( assert ) {
+	assert.equal( Globalize.parseNumber( "3.14" ), 3.14 );
+	assert.equal( es.parseNumber( "3,14" ), 3.14 );
+	assert.equal( ar.parseNumber( "3٫14" ), 3.14 );
+	assert.equal( Globalize.parseNumber( "3.00" ), 3 );
+	assert.equal( Globalize.parseNumber( "12735.0" ), 12735 );
+	assert.equal( Globalize.parseNumber( "0.10" ), 0.1 );
 });
 
-test( "should parse negative decimal", function() {
-	equal( Globalize.parseNumber( "-3.14" ), -3.14 );
+QUnit.test( "should parse negative decimal", function( assert ) {
+	assert.equal( Globalize.parseNumber( "-3.14" ), -3.14 );
 });
 
 /**
  *  Percent
  */
 
-test( "should parse percent", function() {
-	equal( Globalize.parseNumber( "1%" ), 0.01 );
-	equal( Globalize.parseNumber( "01%" ), 0.01 );
-	equal( Globalize.parseNumber( "10%" ), 0.1 );
-	equal( Globalize.parseNumber( "50%" ), 0.5 );
-	equal( Globalize.parseNumber( "100%" ), 1 );
-	equal( Globalize.parseNumber( "0.5%" ), 0.005 );
-	equal( Globalize.parseNumber( "0.5%" ), 0.005 );
-	equal( ar.parseNumber( "50٪" ), 0.5 );
-	equal( Globalize.parseNumber( "-10%" ), -0.1 );
+QUnit.test( "should parse percent", function( assert ) {
+	assert.equal( Globalize.parseNumber( "1%" ), 0.01 );
+	assert.equal( Globalize.parseNumber( "01%" ), 0.01 );
+	assert.equal( Globalize.parseNumber( "10%" ), 0.1 );
+	assert.equal( Globalize.parseNumber( "50%" ), 0.5 );
+	assert.equal( Globalize.parseNumber( "100%" ), 1 );
+	assert.equal( Globalize.parseNumber( "0.5%" ), 0.005 );
+	assert.equal( Globalize.parseNumber( "0.5%" ), 0.005 );
+	assert.equal( ar.parseNumber( "50٪" ), 0.5 );
+	assert.equal( Globalize.parseNumber( "-10%" ), -0.1 );
 });
 
 /**
  *  Scientific notation
  */
-test( "should parse scientific notation numbers", function() {
-	equal( Globalize.parseNumber( "3E-3" ), 0.003 );
-	equal( sv.parseNumber( "3×10^-3" ), 0.003 );
+QUnit.test( "should parse scientific notation numbers", function( assert ) {
+	assert.equal( Globalize.parseNumber( "3E-3" ), 0.003 );
+	assert.equal( sv.parseNumber( "3×10^-3" ), 0.003 );
 });
 
 /**
  *  Infinite number
  */
-test( "should parse infinite numbers", function() {
-	equal( Globalize.parseNumber( "∞" ), Infinity );
-	equal( Globalize.parseNumber( "-∞" ), -Infinity );
-	equal( dz.parseNumber( "གྲངས་མེད" ), Infinity );
+QUnit.test( "should parse infinite numbers", function( assert ) {
+	assert.equal( Globalize.parseNumber( "∞" ), Infinity );
+	assert.equal( Globalize.parseNumber( "-∞" ), -Infinity );
+	assert.equal( dz.parseNumber( "གྲངས་མེད" ), Infinity );
 });
 
 /**
  *  NaN
  */
 
-test( "should parse invalid numbers as NaN", function() {
-	deepEqual( Globalize.parseNumber( "invalid" ), NaN );
-	deepEqual( Globalize.parseNumber( "NaN" ), NaN );
+QUnit.test( "should parse invalid numbers as NaN", function( assert ) {
+	assert.deepEqual( Globalize.parseNumber( "invalid" ), NaN );
+	assert.deepEqual( Globalize.parseNumber( "NaN" ), NaN );
 });
 
 });

--- a/test/unit/core/locale.js
+++ b/test/unit/core/locale.js
@@ -6,17 +6,17 @@ define([
 
 Cldr.load( likelySubtags );
 
-module( "Globalize.locale" );
+QUnit.module( "Globalize.locale" );
 
-test( "should allow String locale", function() {
+QUnit.test( "should allow String locale", function( assert ) {
 	var en = Globalize.locale( "en" );
-	equal( en.locale, "en" );
-	equal( en instanceof Cldr, true );
+	assert.equal( en.locale, "en" );
+	assert.equal( en instanceof Cldr, true );
 });
 
-test( "should allow Cldr instance to be passed as locale", function() {
+QUnit.test( "should allow Cldr instance to be passed as locale", function( assert ) {
 	var en = new Cldr( "en" );
-	equal( Globalize.locale( en ).locale, "en" );
+	assert.equal( Globalize.locale( en ).locale, "en" );
 });
 
 });

--- a/test/unit/date/expand-pattern.js
+++ b/test/unit/date/expand-pattern.js
@@ -12,30 +12,30 @@ Cldr.load( likelySubtags );
 
 cldr = new Cldr( "en" );
 
-module( "Datetime Expand Pattern" );
+QUnit.module( "Datetime Expand Pattern" );
 
-test( "should expand skeleton \"<skeleton>\" (as a String)", function() {
-	equal( expandPattern( "GyMMMEd", cldr ), "E, MMM d, y G" );
+QUnit.test( "should expand skeleton \"<skeleton>\" (as a String)", function( assert ) {
+	assert.equal( expandPattern( "GyMMMEd", cldr ), "E, MMM d, y G" );
 });
 
-test( "should expand {skeleton: \"<skeleton>\"}", function() {
-	equal( expandPattern( { skeleton: "GyMMMEd" }, cldr ), "E, MMM d, y G" );
+QUnit.test( "should expand {skeleton: \"<skeleton>\"}", function( assert ) {
+	assert.equal( expandPattern( { skeleton: "GyMMMEd" }, cldr ), "E, MMM d, y G" );
 });
 
-test( "should expand {date: \"(full, ...)\"}", function() {
-	equal( expandPattern( { date: "full" }, cldr ), "EEEE, MMMM d, y" );
+QUnit.test( "should expand {date: \"(full, ...)\"}", function( assert ) {
+	assert.equal( expandPattern( { date: "full" }, cldr ), "EEEE, MMMM d, y" );
 });
 
-test( "should expand {time: \"(full, ...)\"}", function() {
-	equal( expandPattern( { time: "full" }, cldr ), "h:mm:ss a zzzz" );
+QUnit.test( "should expand {time: \"(full, ...)\"}", function( assert ) {
+	assert.equal( expandPattern( { time: "full" }, cldr ), "h:mm:ss a zzzz" );
 });
 
-test( "should expand {datetime: \"(full, ...)\"}", function() {
-	equal( expandPattern( { datetime: "full" }, cldr ), "EEEE, MMMM d, y 'at' h:mm:ss a zzzz" );
+QUnit.test( "should expand {datetime: \"(full, ...)\"}", function( assert ) {
+	assert.equal( expandPattern( { datetime: "full" }, cldr ), "EEEE, MMMM d, y 'at' h:mm:ss a zzzz" );
 });
 
-test( "should expand {pattern: \"<pattern>\"}", function() {
-	equal( expandPattern( { pattern: "MMM d" }, cldr ), "MMM d" );
+QUnit.test( "should expand {pattern: \"<pattern>\"}", function( assert ) {
+	assert.equal( expandPattern( { pattern: "MMM d" }, cldr ), "MMM d" );
 });
 
 });

--- a/test/unit/date/format.js
+++ b/test/unit/date/format.js
@@ -23,254 +23,254 @@ Cldr.load( weekData );
 
 cldr = new Cldr( "en" );
 
-module( "Datetime Format" );
+QUnit.module( "Datetime Format" );
 
 /**
  *  Era
  */
 
-test( "should format era (G|GG|GGG)", function() {
-	equal( format( date1, "G", cldr ), "AD" );
-	equal( format( year0, "G", cldr ), "AD" );
-	equal( format( yearBc, "G", cldr ), "BC" );
-	equal( format( date1, "GG", cldr ), "AD" );
-	equal( format( year0, "GG", cldr ), "AD" );
-	equal( format( yearBc, "GG", cldr ), "BC" );
-	equal( format( date1, "GGG", cldr ), "AD" );
-	equal( format( year0, "GGG", cldr ), "AD" );
-	equal( format( yearBc, "GGG", cldr ), "BC" );
+QUnit.test( "should format era (G|GG|GGG)", function( assert ) {
+	assert.equal( format( date1, "G", cldr ), "AD" );
+	assert.equal( format( year0, "G", cldr ), "AD" );
+	assert.equal( format( yearBc, "G", cldr ), "BC" );
+	assert.equal( format( date1, "GG", cldr ), "AD" );
+	assert.equal( format( year0, "GG", cldr ), "AD" );
+	assert.equal( format( yearBc, "GG", cldr ), "BC" );
+	assert.equal( format( date1, "GGG", cldr ), "AD" );
+	assert.equal( format( year0, "GGG", cldr ), "AD" );
+	assert.equal( format( yearBc, "GGG", cldr ), "BC" );
 });
 
-test( "should format era (GGGG)", function() {
-	equal( format( date1, "GGGG", cldr ), "Anno Domini" );
-	equal( format( year0, "GGGG", cldr ), "Anno Domini" );
-	equal( format( yearBc, "GGGG", cldr ), "Before Christ" );
+QUnit.test( "should format era (GGGG)", function( assert ) {
+	assert.equal( format( date1, "GGGG", cldr ), "Anno Domini" );
+	assert.equal( format( year0, "GGGG", cldr ), "Anno Domini" );
+	assert.equal( format( yearBc, "GGGG", cldr ), "Before Christ" );
 });
 
-test( "should format era (GGGGG)", function() {
-	equal( format( date1, "GGGGG", cldr ), "A" );
-	equal( format( year0, "GGGGG", cldr ), "A" );
-	equal( format( yearBc, "GGGGG", cldr ), "B" );
+QUnit.test( "should format era (GGGGG)", function( assert ) {
+	assert.equal( format( date1, "GGGGG", cldr ), "A" );
+	assert.equal( format( year0, "GGGGG", cldr ), "A" );
+	assert.equal( format( yearBc, "GGGGG", cldr ), "B" );
 });
 
 /**
  *  Year
  */
 
-test( "should format year (y) with no padding", function() {
-	equal( format( date2, "y", cldr ), "2010" );
-	equal( format( date1, "y", cldr ), "1982" );
-	equal( format( year0, "y", cldr ), "0" );
+QUnit.test( "should format year (y) with no padding", function( assert ) {
+	assert.equal( format( date2, "y", cldr ), "2010" );
+	assert.equal( format( date1, "y", cldr ), "1982" );
+	assert.equal( format( year0, "y", cldr ), "0" );
 });
 
-test( "should format year (yy) with padding, and limit 2 digits", function() {
-	equal( format( date2, "yy", cldr ), "10" );
-	equal( format( date1, "yy", cldr ), "82" );
-	equal( format( year0, "yy", cldr ), "00" );
+QUnit.test( "should format year (yy) with padding, and limit 2 digits", function( assert ) {
+	assert.equal( format( date2, "yy", cldr ), "10" );
+	assert.equal( format( date1, "yy", cldr ), "82" );
+	assert.equal( format( year0, "yy", cldr ), "00" );
 });
 
-test( "should format year (yyy+) with padding", function() {
-	equal( format( date1, "yyy", cldr ), "1982" );
-	equal( format( date2, "yyy", cldr ), "2010" );
-	equal( format( year0, "yyyy", cldr ), "0000" );
-	equal( format( date1, "yyyyy", cldr ), "01982" );
-	equal( format( date2, "yyyyy", cldr ), "02010" );
+QUnit.test( "should format year (yyy+) with padding", function( assert ) {
+	assert.equal( format( date1, "yyy", cldr ), "1982" );
+	assert.equal( format( date2, "yyy", cldr ), "2010" );
+	assert.equal( format( year0, "yyyy", cldr ), "0000" );
+	assert.equal( format( date1, "yyyyy", cldr ), "01982" );
+	assert.equal( format( date2, "yyyyy", cldr ), "02010" );
 });
 
-test( "should format year in \"week of year\" (Y) with no padding", function() {
-	equal( format( date3, "Y", cldr ), "1982" );
-	equal( format( date4, "Y", cldr ), "1994" );
+QUnit.test( "should format year in \"week of year\" (Y) with no padding", function( assert ) {
+	assert.equal( format( date3, "Y", cldr ), "1982" );
+	assert.equal( format( date4, "Y", cldr ), "1994" );
 });
 
-test( "should format year in \"week of year\" (YY) with padding, and limit 2 digits", function() {
-	equal( format( date3, "YY", cldr ), "82" );
-	equal( format( date4, "YY", cldr ), "94" );
+QUnit.test( "should format year in \"week of year\" (YY) with padding, and limit 2 digits", function( assert ) {
+	assert.equal( format( date3, "YY", cldr ), "82" );
+	assert.equal( format( date4, "YY", cldr ), "94" );
 });
 
-test( "should format year in \"week of year\" (YYY+) with padding", function() {
-	equal( format( date3, "YYY", cldr ), "1982" );
-	equal( format( date4, "YYY", cldr ), "1994" );
-	equal( format( date3, "YYYYY", cldr ), "01982" );
-	equal( format( date4, "YYYYY", cldr ), "01994" );
+QUnit.test( "should format year in \"week of year\" (YYY+) with padding", function( assert ) {
+	assert.equal( format( date3, "YYY", cldr ), "1982" );
+	assert.equal( format( date4, "YYY", cldr ), "1994" );
+	assert.equal( format( date3, "YYYYY", cldr ), "01982" );
+	assert.equal( format( date4, "YYYYY", cldr ), "01994" );
 });
 
 /**
  *  Quarter
  */
 
-test( "should format quarter (Q|q) with no padding", function() {
-	equal( format( date1, "Q", cldr ), "1" );
-	equal( format( date2, "Q", cldr ), "3" );
-	equal( format( date1, "q", cldr ), "1" );
-	equal( format( date2, "q", cldr ), "3" );
+QUnit.test( "should format quarter (Q|q) with no padding", function( assert ) {
+	assert.equal( format( date1, "Q", cldr ), "1" );
+	assert.equal( format( date2, "Q", cldr ), "3" );
+	assert.equal( format( date1, "q", cldr ), "1" );
+	assert.equal( format( date2, "q", cldr ), "3" );
 });
 
-test( "should format quarter (QQ|qq) with padding", function() {
-	equal( format( date1, "QQ", cldr ), "01" );
-	equal( format( date2, "QQ", cldr ), "03" );
-	equal( format( date1, "qq", cldr ), "01" );
-	equal( format( date2, "qq", cldr ), "03" );
+QUnit.test( "should format quarter (QQ|qq) with padding", function( assert ) {
+	assert.equal( format( date1, "QQ", cldr ), "01" );
+	assert.equal( format( date2, "QQ", cldr ), "03" );
+	assert.equal( format( date1, "qq", cldr ), "01" );
+	assert.equal( format( date2, "qq", cldr ), "03" );
 });
 
-test( "should format quarter (QQQ|qqq)", function() {
-	equal( format( date1, "QQQ", cldr ), "Q1" );
-	equal( format( date2, "QQQ", cldr ), "Q3" );
-	equal( format( date1, "qqq", cldr ), "Q1" );
-	equal( format( date2, "qqq", cldr ), "Q3" );
+QUnit.test( "should format quarter (QQQ|qqq)", function( assert ) {
+	assert.equal( format( date1, "QQQ", cldr ), "Q1" );
+	assert.equal( format( date2, "QQQ", cldr ), "Q3" );
+	assert.equal( format( date1, "qqq", cldr ), "Q1" );
+	assert.equal( format( date2, "qqq", cldr ), "Q3" );
 });
 
-test( "should format quarter (QQQQ|qqqq) with padding", function() {
-	equal( format( date1, "QQQQ", cldr ), "1st quarter" );
-	equal( format( date2, "QQQQ", cldr ), "3rd quarter" );
-	equal( format( date1, "qqqq", cldr ), "1st quarter" );
-	equal( format( date2, "qqqq", cldr ), "3rd quarter" );
+QUnit.test( "should format quarter (QQQQ|qqqq) with padding", function( assert ) {
+	assert.equal( format( date1, "QQQQ", cldr ), "1st quarter" );
+	assert.equal( format( date2, "QQQQ", cldr ), "3rd quarter" );
+	assert.equal( format( date1, "qqqq", cldr ), "1st quarter" );
+	assert.equal( format( date2, "qqqq", cldr ), "3rd quarter" );
 });
 
 /**
  *  Month
  */
 
-test( "should format month (M|L) with no padding", function() {
-	equal( format( date1, "M", cldr ), "1" );
-	equal( format( date2, "M", cldr ), "9" );
-	equal( format( date1, "L", cldr ), "1" );
-	equal( format( date2, "L", cldr ), "9" );
+QUnit.test( "should format month (M|L) with no padding", function( assert ) {
+	assert.equal( format( date1, "M", cldr ), "1" );
+	assert.equal( format( date2, "M", cldr ), "9" );
+	assert.equal( format( date1, "L", cldr ), "1" );
+	assert.equal( format( date2, "L", cldr ), "9" );
 });
 
-test( "should format month (MM|LL) with padding", function() {
-	equal( format( date1, "MM", cldr ), "01" );
-	equal( format( date2, "MM", cldr ), "09" );
-	equal( format( date1, "LL", cldr ), "01" );
-	equal( format( date2, "LL", cldr ), "09" );
+QUnit.test( "should format month (MM|LL) with padding", function( assert ) {
+	assert.equal( format( date1, "MM", cldr ), "01" );
+	assert.equal( format( date2, "MM", cldr ), "09" );
+	assert.equal( format( date1, "LL", cldr ), "01" );
+	assert.equal( format( date2, "LL", cldr ), "09" );
 });
 
-test( "should format month (MMM|LLL)", function() {
-	equal( format( date1, "MMM", cldr ), "Jan" );
-	equal( format( date2, "MMM", cldr ), "Sep" );
-	equal( format( date1, "LLL", cldr ), "Jan" );
-	equal( format( date2, "LLL", cldr ), "Sep" );
+QUnit.test( "should format month (MMM|LLL)", function( assert ) {
+	assert.equal( format( date1, "MMM", cldr ), "Jan" );
+	assert.equal( format( date2, "MMM", cldr ), "Sep" );
+	assert.equal( format( date1, "LLL", cldr ), "Jan" );
+	assert.equal( format( date2, "LLL", cldr ), "Sep" );
 });
 
-test( "should format month (MMMM|LLLL)", function() {
-	equal( format( date1, "MMMM", cldr ), "January" );
-	equal( format( date2, "MMMM", cldr ), "September" );
-	equal( format( date1, "LLLL", cldr ), "January" );
-	equal( format( date2, "LLLL", cldr ), "September" );
+QUnit.test( "should format month (MMMM|LLLL)", function( assert ) {
+	assert.equal( format( date1, "MMMM", cldr ), "January" );
+	assert.equal( format( date2, "MMMM", cldr ), "September" );
+	assert.equal( format( date1, "LLLL", cldr ), "January" );
+	assert.equal( format( date2, "LLLL", cldr ), "September" );
 });
 
-test( "should format month (MMMMM|LLLLL)", function() {
-	equal( format( date1, "MMMMM", cldr ), "J" );
-	equal( format( date2, "MMMMM", cldr ), "S" );
-	equal( format( date1, "LLLLL", cldr ), "J" );
-	equal( format( date2, "LLLLL", cldr ), "S" );
+QUnit.test( "should format month (MMMMM|LLLLL)", function( assert ) {
+	assert.equal( format( date1, "MMMMM", cldr ), "J" );
+	assert.equal( format( date2, "MMMMM", cldr ), "S" );
+	assert.equal( format( date1, "LLLLL", cldr ), "J" );
+	assert.equal( format( date2, "LLLLL", cldr ), "S" );
 });
 
 /**
  *  Week
  */
 
-test( "should format week of year (w) with no padding", function() {
-	equal( format( date1, "w", cldr ), "1" );
-	equal( format( date2, "w", cldr ), "38" );
+QUnit.test( "should format week of year (w) with no padding", function( assert ) {
+	assert.equal( format( date1, "w", cldr ), "1" );
+	assert.equal( format( date2, "w", cldr ), "38" );
 });
 
-test( "should format week of year (ww) with padding", function() {
-	equal( format( date1, "ww", cldr ), "01" );
-	equal( format( date2, "ww", cldr ), "38" );
+QUnit.test( "should format week of year (ww) with padding", function( assert ) {
+	assert.equal( format( date1, "ww", cldr ), "01" );
+	assert.equal( format( date2, "ww", cldr ), "38" );
 });
 
-test( "should format week of month (W)", function() {
-	equal( format( date1, "W", cldr ), "1" );
-	equal( format( date2, "W", cldr ), "3" );
-	equal( format( date3, "W", cldr ), "5" );
+QUnit.test( "should format week of month (W)", function( assert ) {
+	assert.equal( format( date1, "W", cldr ), "1" );
+	assert.equal( format( date2, "W", cldr ), "3" );
+	assert.equal( format( date3, "W", cldr ), "5" );
 });
 
 /**
  *  Day
  */
 
-test( "should format day (d) with no padding", function() {
-	equal( format( date1, "d", cldr ), "2" );
-	equal( format( date2, "d", cldr ), "15" );
+QUnit.test( "should format day (d) with no padding", function( assert ) {
+	assert.equal( format( date1, "d", cldr ), "2" );
+	assert.equal( format( date2, "d", cldr ), "15" );
 });
 
-test( "should format day (dd) with padding", function() {
-	equal( format( date1, "dd", cldr ), "02" );
-	equal( format( date2, "dd", cldr ), "15" );
+QUnit.test( "should format day (dd) with padding", function( assert ) {
+	assert.equal( format( date1, "dd", cldr ), "02" );
+	assert.equal( format( date2, "dd", cldr ), "15" );
 });
 
-test( "should format day of year (D) with no padding", function() {
-	equal( format( date1, "D", cldr ), "2" );
-	equal( format( date2, "D", cldr ), "258" );
+QUnit.test( "should format day of year (D) with no padding", function( assert ) {
+	assert.equal( format( date1, "D", cldr ), "2" );
+	assert.equal( format( date2, "D", cldr ), "258" );
 });
 
-test( "should format day of year (DD|DDD) with padding", function() {
-	equal( format( date1, "DD", cldr ), "02" );
-	equal( format( date1, "DDD", cldr ), "002" );
-	equal( format( date2, "DD", cldr ), "258" );
+QUnit.test( "should format day of year (DD|DDD) with padding", function( assert ) {
+	assert.equal( format( date1, "DD", cldr ), "02" );
+	assert.equal( format( date1, "DDD", cldr ), "002" );
+	assert.equal( format( date2, "DD", cldr ), "258" );
 });
 
-test( "should format day of week in month (F)", function() {
-	equal( format( date1, "F", cldr ), "1" );
-	equal( format( date2, "F", cldr ), "3" );
+QUnit.test( "should format day of week in month (F)", function( assert ) {
+	assert.equal( format( date1, "F", cldr ), "1" );
+	assert.equal( format( date2, "F", cldr ), "3" );
 });
 
 /**
  *  Week day
  */
 
-test( "should format local day of week (e|c) with no padding", function() {
-	equal( format( date1, "e", cldr ), "7" );
-	equal( format( date2, "e", cldr ), "4" );
-	equal( format( date1, "c", cldr ), "7" );
-	equal( format( date2, "c", cldr ), "4" );
+QUnit.test( "should format local day of week (e|c) with no padding", function( assert ) {
+	assert.equal( format( date1, "e", cldr ), "7" );
+	assert.equal( format( date2, "e", cldr ), "4" );
+	assert.equal( format( date1, "c", cldr ), "7" );
+	assert.equal( format( date2, "c", cldr ), "4" );
 });
 
-test( "should format local day of week (ee|cc) with padding", function() {
-	equal( format( date1, "ee", cldr ), "07" );
-	equal( format( date2, "ee", cldr ), "04" );
-	equal( format( date1, "cc", cldr ), "07" );
-	equal( format( date2, "cc", cldr ), "04" );
+QUnit.test( "should format local day of week (ee|cc) with padding", function( assert ) {
+	assert.equal( format( date1, "ee", cldr ), "07" );
+	assert.equal( format( date2, "ee", cldr ), "04" );
+	assert.equal( format( date1, "cc", cldr ), "07" );
+	assert.equal( format( date2, "cc", cldr ), "04" );
 });
 
-test( "should format local day of week (E|EE|EEE|eee|ccc)", function() {
-	equal( format( date1, "E", cldr ), "Sat" );
-	equal( format( date2, "E", cldr ), "Wed" );
-	equal( format( date1, "EE", cldr ), "Sat" );
-	equal( format( date2, "EE", cldr ), "Wed" );
-	equal( format( date1, "EEE", cldr ), "Sat" );
-	equal( format( date2, "EEE", cldr ), "Wed" );
-	equal( format( date1, "eee", cldr ), "Sat" );
-	equal( format( date2, "eee", cldr ), "Wed" );
-	equal( format( date1, "ccc", cldr ), "Sat" );
-	equal( format( date2, "ccc", cldr ), "Wed" );
+QUnit.test( "should format local day of week (E|EE|EEE|eee|ccc)", function( assert ) {
+	assert.equal( format( date1, "E", cldr ), "Sat" );
+	assert.equal( format( date2, "E", cldr ), "Wed" );
+	assert.equal( format( date1, "EE", cldr ), "Sat" );
+	assert.equal( format( date2, "EE", cldr ), "Wed" );
+	assert.equal( format( date1, "EEE", cldr ), "Sat" );
+	assert.equal( format( date2, "EEE", cldr ), "Wed" );
+	assert.equal( format( date1, "eee", cldr ), "Sat" );
+	assert.equal( format( date2, "eee", cldr ), "Wed" );
+	assert.equal( format( date1, "ccc", cldr ), "Sat" );
+	assert.equal( format( date2, "ccc", cldr ), "Wed" );
 });
 
-test( "should format local day of week (EEEE|eeee|cccc)", function() {
-	equal( format( date1, "EEEE", cldr ), "Saturday" );
-	equal( format( date2, "EEEE", cldr ), "Wednesday" );
-	equal( format( date1, "eeee", cldr ), "Saturday" );
-	equal( format( date2, "eeee", cldr ), "Wednesday" );
-	equal( format( date1, "cccc", cldr ), "Saturday" );
-	equal( format( date2, "cccc", cldr ), "Wednesday" );
+QUnit.test( "should format local day of week (EEEE|eeee|cccc)", function( assert ) {
+	assert.equal( format( date1, "EEEE", cldr ), "Saturday" );
+	assert.equal( format( date2, "EEEE", cldr ), "Wednesday" );
+	assert.equal( format( date1, "eeee", cldr ), "Saturday" );
+	assert.equal( format( date2, "eeee", cldr ), "Wednesday" );
+	assert.equal( format( date1, "cccc", cldr ), "Saturday" );
+	assert.equal( format( date2, "cccc", cldr ), "Wednesday" );
 });
 
-test( "should format local day of week (EEEEE|eeeee|ccccc)", function() {
-	equal( format( date1, "EEEEE", cldr ), "S" );
-	equal( format( date2, "EEEEE", cldr ), "W" );
-	equal( format( date1, "eeeee", cldr ), "S" );
-	equal( format( date2, "eeeee", cldr ), "W" );
-	equal( format( date1, "ccccc", cldr ), "S" );
-	equal( format( date2, "ccccc", cldr ), "W" );
+QUnit.test( "should format local day of week (EEEEE|eeeee|ccccc)", function( assert ) {
+	assert.equal( format( date1, "EEEEE", cldr ), "S" );
+	assert.equal( format( date2, "EEEEE", cldr ), "W" );
+	assert.equal( format( date1, "eeeee", cldr ), "S" );
+	assert.equal( format( date2, "eeeee", cldr ), "W" );
+	assert.equal( format( date1, "ccccc", cldr ), "S" );
+	assert.equal( format( date2, "ccccc", cldr ), "W" );
 });
 
-test( "should format local day of week (EEEEEE|eeeeee|cccccc)", function() {
-	equal( format( date1, "EEEEEE", cldr ), "Sa" );
-	equal( format( date2, "EEEEEE", cldr ), "We" );
-	equal( format( date1, "eeeeee", cldr ), "Sa" );
-	equal( format( date2, "eeeeee", cldr ), "We" );
-	equal( format( date1, "cccccc", cldr ), "Sa" );
-	equal( format( date2, "cccccc", cldr ), "We" );
+QUnit.test( "should format local day of week (EEEEEE|eeeeee|cccccc)", function( assert ) {
+	assert.equal( format( date1, "EEEEEE", cldr ), "Sa" );
+	assert.equal( format( date2, "EEEEEE", cldr ), "We" );
+	assert.equal( format( date1, "eeeeee", cldr ), "Sa" );
+	assert.equal( format( date2, "eeeeee", cldr ), "We" );
+	assert.equal( format( date1, "cccccc", cldr ), "Sa" );
+	assert.equal( format( date2, "cccccc", cldr ), "We" );
 });
 
 // TODO all
@@ -279,120 +279,120 @@ test( "should format local day of week (EEEEEE|eeeeee|cccccc)", function() {
  *  Period
  */
 
-test( "should format period (a)", function() {
-	equal( format( date1, "a", cldr ), "AM" );
-	equal( format( date2, "a", cldr ), "PM" );
+QUnit.test( "should format period (a)", function( assert ) {
+	assert.equal( format( date1, "a", cldr ), "AM" );
+	assert.equal( format( date2, "a", cldr ), "PM" );
 });
 
 /**
  *  Hour
  */
 
-test( "should format hour (h) using 12-hour-cycle [1-12] with no padding", function() {
-	equal( format( date1, "h", cldr ), "9" );
-	equal( format( date2, "h", cldr ), "5" );
-	equal( format( new Date( 0, 0, 0, 0 ), "h", cldr ), "12" );
+QUnit.test( "should format hour (h) using 12-hour-cycle [1-12] with no padding", function( assert ) {
+	assert.equal( format( date1, "h", cldr ), "9" );
+	assert.equal( format( date2, "h", cldr ), "5" );
+	assert.equal( format( new Date( 0, 0, 0, 0 ), "h", cldr ), "12" );
 });
 
-test( "should format hour (hh) using 12-hour-cycle [1-12] with padding", function() {
-	equal( format( date1, "hh", cldr ), "09" );
-	equal( format( date2, "hh", cldr ), "05" );
-	equal( format( new Date( 0, 0, 0, 0 ), "hh", cldr ), "12" );
+QUnit.test( "should format hour (hh) using 12-hour-cycle [1-12] with padding", function( assert ) {
+	assert.equal( format( date1, "hh", cldr ), "09" );
+	assert.equal( format( date2, "hh", cldr ), "05" );
+	assert.equal( format( new Date( 0, 0, 0, 0 ), "hh", cldr ), "12" );
 });
 
-test( "should format hour (H) using 24-hour-cycle [0-23] with no padding", function() {
-	equal( format( date1, "H", cldr ), "9" );
-	equal( format( date2, "H", cldr ), "17" );
-	equal( format( new Date( 0, 0, 0, 0 ), "H", cldr ), "0" );
+QUnit.test( "should format hour (H) using 24-hour-cycle [0-23] with no padding", function( assert ) {
+	assert.equal( format( date1, "H", cldr ), "9" );
+	assert.equal( format( date2, "H", cldr ), "17" );
+	assert.equal( format( new Date( 0, 0, 0, 0 ), "H", cldr ), "0" );
 });
 
-test( "should format hour (HH) using 24-hour-cycle [0-23] with padding", function() {
-	equal( format( date1, "HH", cldr ), "09" );
-	equal( format( date2, "HH", cldr ), "17" );
-	equal( format( new Date( 0, 0, 0, 0 ), "HH", cldr ), "00" );
+QUnit.test( "should format hour (HH) using 24-hour-cycle [0-23] with padding", function( assert ) {
+	assert.equal( format( date1, "HH", cldr ), "09" );
+	assert.equal( format( date2, "HH", cldr ), "17" );
+	assert.equal( format( new Date( 0, 0, 0, 0 ), "HH", cldr ), "00" );
 });
 
-test( "should format hour (K) using 12-hour-cycle [0-11] with no padding", function() {
-	equal( format( date1, "K", cldr ), "9" );
-	equal( format( date2, "K", cldr ), "5" );
-	equal( format( new Date( 0, 0, 0, 0 ), "K", cldr ), "0" );
+QUnit.test( "should format hour (K) using 12-hour-cycle [0-11] with no padding", function( assert ) {
+	assert.equal( format( date1, "K", cldr ), "9" );
+	assert.equal( format( date2, "K", cldr ), "5" );
+	assert.equal( format( new Date( 0, 0, 0, 0 ), "K", cldr ), "0" );
 });
 
-test( "should format hour (KK) using 12-hour-cycle [0-11] with padding", function() {
-	equal( format( date1, "KK", cldr ), "09" );
-	equal( format( date2, "KK", cldr ), "05" );
-	equal( format( new Date( 0, 0, 0, 0 ), "KK", cldr ), "00" );
+QUnit.test( "should format hour (KK) using 12-hour-cycle [0-11] with padding", function( assert ) {
+	assert.equal( format( date1, "KK", cldr ), "09" );
+	assert.equal( format( date2, "KK", cldr ), "05" );
+	assert.equal( format( new Date( 0, 0, 0, 0 ), "KK", cldr ), "00" );
 });
 
-test( "should format hour (k) using 24-hour-cycle [1-24] with no padding", function() {
-	equal( format( date1, "k", cldr ), "9" );
-	equal( format( date2, "k", cldr ), "17" );
-	equal( format( new Date( 0, 0, 0, 0 ), "k", cldr ), "24" );
+QUnit.test( "should format hour (k) using 24-hour-cycle [1-24] with no padding", function( assert ) {
+	assert.equal( format( date1, "k", cldr ), "9" );
+	assert.equal( format( date2, "k", cldr ), "17" );
+	assert.equal( format( new Date( 0, 0, 0, 0 ), "k", cldr ), "24" );
 });
 
-test( "should format hour (kk) using 24-hour-cycle [1-24] with padding", function() {
-	equal( format( date1, "kk", cldr ), "09" );
-	equal( format( date2, "kk", cldr ), "17" );
-	equal( format( new Date( 0, 0, 0, 0 ), "kk", cldr ), "24" );
+QUnit.test( "should format hour (kk) using 24-hour-cycle [1-24] with padding", function( assert ) {
+	assert.equal( format( date1, "kk", cldr ), "09" );
+	assert.equal( format( date2, "kk", cldr ), "17" );
+	assert.equal( format( new Date( 0, 0, 0, 0 ), "kk", cldr ), "24" );
 });
 
-test( "should format hour (j) using preferred hour format for the locale (h, H, K, or k) with no padding", function() {
-	equal( format( date2, "j", cldr ), "5" );
-	equal( format( date2, "j", new Cldr( "pt-BR" ) ), "17" );
-	equal( format( date2, "j", new Cldr( "de" ) ), "17" );
-	equal( format( date2, "j", new Cldr( "en-IN" ) ), "5" );
-	equal( format( date2, "j", new Cldr( "en-GB" ) ), "17" );
-	equal( format( date2, "j", new Cldr( "ru" ) ), "17" );
+QUnit.test( "should format hour (j) using preferred hour format for the locale (h, H, K, or k) with no padding", function( assert ) {
+	assert.equal( format( date2, "j", cldr ), "5" );
+	assert.equal( format( date2, "j", new Cldr( "pt-BR" ) ), "17" );
+	assert.equal( format( date2, "j", new Cldr( "de" ) ), "17" );
+	assert.equal( format( date2, "j", new Cldr( "en-IN" ) ), "5" );
+	assert.equal( format( date2, "j", new Cldr( "en-GB" ) ), "17" );
+	assert.equal( format( date2, "j", new Cldr( "ru" ) ), "17" );
 });
 
-test( "should format hour (jj) using preferred hour format for the locale (h, H, K, or k) with padding", function() {
-	equal( format( date1, "jj", cldr ), "09" );
-	equal( format( date2, "jj", cldr ), "05" );
-	equal( format( new Date( 0, 0, 0, 0 ), "jj", cldr ), "12" );
+QUnit.test( "should format hour (jj) using preferred hour format for the locale (h, H, K, or k) with padding", function( assert ) {
+	assert.equal( format( date1, "jj", cldr ), "09" );
+	assert.equal( format( date2, "jj", cldr ), "05" );
+	assert.equal( format( new Date( 0, 0, 0, 0 ), "jj", cldr ), "12" );
 });
 
 /**
  *  Minute
  */
 
-test( "should format minute (m) with no padding", function() {
-	equal( format( date1, "m", cldr ), "5" );
-	equal( format( date2, "m", cldr ), "35" );
+QUnit.test( "should format minute (m) with no padding", function( assert ) {
+	assert.equal( format( date1, "m", cldr ), "5" );
+	assert.equal( format( date2, "m", cldr ), "35" );
 });
 
-test( "should format minute (mm) with padding", function() {
-	equal( format( date1, "mm", cldr ), "05" );
-	equal( format( date2, "mm", cldr ), "35" );
+QUnit.test( "should format minute (mm) with padding", function( assert ) {
+	assert.equal( format( date1, "mm", cldr ), "05" );
+	assert.equal( format( date2, "mm", cldr ), "35" );
 });
 
 /**
  *  Second
  */
 
-test( "should format second (s) with no padding", function() {
-	equal( format( date1, "s", cldr ), "59" );
-	equal( format( date2, "s", cldr ), "7" );
+QUnit.test( "should format second (s) with no padding", function( assert ) {
+	assert.equal( format( date1, "s", cldr ), "59" );
+	assert.equal( format( date2, "s", cldr ), "7" );
 });
 
-test( "should format second (ss) with padding", function() {
-	equal( format( date1, "ss", cldr ), "59" );
-	equal( format( date2, "ss", cldr ), "07" );
+QUnit.test( "should format second (ss) with padding", function( assert ) {
+	assert.equal( format( date1, "ss", cldr ), "59" );
+	assert.equal( format( date2, "ss", cldr ), "07" );
 });
 
-test( "should format various milliseconds (S+)", function() {
-	equal( format( date2, "S", cldr ), "4" );
-	equal( format( date2, "SS", cldr ), "37" );
-	equal( format( date2, "SSS", cldr ), "369" );
-	equal( format( date2, "SSSS", cldr ), "3690" );
-	equal( format( date2, "SSSSS", cldr ), "36900" );
+QUnit.test( "should format various milliseconds (S+)", function( assert ) {
+	assert.equal( format( date2, "S", cldr ), "4" );
+	assert.equal( format( date2, "SS", cldr ), "37" );
+	assert.equal( format( date2, "SSS", cldr ), "369" );
+	assert.equal( format( date2, "SSSS", cldr ), "3690" );
+	assert.equal( format( date2, "SSSSS", cldr ), "36900" );
 });
 
-test( "should format various milliseconds (A+)", function() {
-	equal( format( date2, "A", cldr ), "633074" );
-	equal( format( date2, "AA", cldr ), "6330737" );
-	equal( format( date2, "AAA", cldr ), "63307369" );
-	equal( format( date2, "AAAA", cldr ), "633073690" );
-	equal( format( date2, "AAAAA", cldr ), "6330736900" );
+QUnit.test( "should format various milliseconds (A+)", function( assert ) {
+	assert.equal( format( date2, "A", cldr ), "633074" );
+	assert.equal( format( date2, "AA", cldr ), "6330737" );
+	assert.equal( format( date2, "AAA", cldr ), "63307369" );
+	assert.equal( format( date2, "AAAA", cldr ), "633073690" );
+	assert.equal( format( date2, "AAAAA", cldr ), "6330736900" );
 });
 
 /**

--- a/test/unit/date/parse.js
+++ b/test/unit/date/parse.js
@@ -18,291 +18,291 @@ Cldr.load( weekData );
 
 cldr = new Cldr( "en" );
 
-module( "Datetime Parse" );
+QUnit.module( "Datetime Parse" );
 
 /**
  *  Era
  */
 
-test( "should parse era (G|GG|GGG)", function() {
+QUnit.test( "should parse era (G|GG|GGG)", function( assert ) {
 	date1 = new Date( 0, 0 );
 	date2 = new Date( 0, 0 );
 	date1.setFullYear( 4 );
 	date2.setFullYear( -4 );
-	deepEqual( parse( "AD 4", "G y", cldr ), date1 );
-	deepEqual( parse( "BC 5", "G y", cldr ), date2 );
-	deepEqual( parse( "AD 4", "GG y", cldr ), date1 );
-	deepEqual( parse( "BC 5", "GG y", cldr ), date2 );
-	deepEqual( parse( "AD 4", "GGG y", cldr ), date1 );
-	deepEqual( parse( "BC 5", "GGG y", cldr ), date2 );
+	assert.deepEqual( parse( "AD 4", "G y", cldr ), date1 );
+	assert.deepEqual( parse( "BC 5", "G y", cldr ), date2 );
+	assert.deepEqual( parse( "AD 4", "GG y", cldr ), date1 );
+	assert.deepEqual( parse( "BC 5", "GG y", cldr ), date2 );
+	assert.deepEqual( parse( "AD 4", "GGG y", cldr ), date1 );
+	assert.deepEqual( parse( "BC 5", "GGG y", cldr ), date2 );
 });
 
-test( "should parse era (GGGG)", function() {
+QUnit.test( "should parse era (GGGG)", function( assert ) {
 	date1 = new Date( 0, 0 );
 	date2 = new Date( 0, 0 );
 	date1.setFullYear( 4 );
 	date2.setFullYear( -4 );
-	deepEqual( parse( "Anno Domini 4", "GGGG y", cldr ), date1 );
-	deepEqual( parse( "Before Christ 5", "GGGG y", cldr ), date2 );
+	assert.deepEqual( parse( "Anno Domini 4", "GGGG y", cldr ), date1 );
+	assert.deepEqual( parse( "Before Christ 5", "GGGG y", cldr ), date2 );
 });
 
-test( "should parse era (GGGGG)", function() {
+QUnit.test( "should parse era (GGGGG)", function( assert ) {
 	date1 = new Date( 0, 0 );
 	date2 = new Date( 0, 0 );
 	date1.setFullYear( 4 );
 	date2.setFullYear( -4 );
-	deepEqual( parse( "A 4", "GGGGG y", cldr ), date1 );
-	deepEqual( parse( "B 5", "GGGGG y", cldr ), date2 );
+	assert.deepEqual( parse( "A 4", "GGGGG y", cldr ), date1 );
+	assert.deepEqual( parse( "B 5", "GGGGG y", cldr ), date2 );
 });
 
 /**
  *  Year
  */
 
-test( "should parse year (y) with no padding", function() {
-	deepEqual( parse( "1982", "y", cldr ), new Date( 1982, 0 ) );
+QUnit.test( "should parse year (y) with no padding", function( assert ) {
+	assert.deepEqual( parse( "1982", "y", cldr ), new Date( 1982, 0 ) );
 });
 
-test( "should parse year (yy) with padding, and limit 2 digits", function() {
+QUnit.test( "should parse year (yy) with padding, and limit 2 digits", function( assert ) {
 	// This may change in the future, eg. 82 could eventually be 2082.
-	deepEqual( parse( "82", "yy", cldr ), new Date( 1982, 0 ) );
+	assert.deepEqual( parse( "82", "yy", cldr ), new Date( 1982, 0 ) );
 });
 
-test( "should parse year (yyy+) with padding", function() {
-	deepEqual( parse( "1982", "yyy", cldr ), new Date( 1982, 0 ) );
-	deepEqual( parse( "01982", "yyyyy", cldr ), new Date( 1982, 0 ) );
+QUnit.test( "should parse year (yyy+) with padding", function( assert ) {
+	assert.deepEqual( parse( "1982", "yyy", cldr ), new Date( 1982, 0 ) );
+	assert.deepEqual( parse( "01982", "yyyyy", cldr ), new Date( 1982, 0 ) );
 });
 
 /**
  *  Month
  */
 
-test( "should parse month (M|L) with no padding", function() {
+QUnit.test( "should parse month (M|L) with no padding", function( assert ) {
 	date1 = new Date();
 	date1.setMonth( 0 );
 	date1 = startOf( date1, "month" );
-	deepEqual( parse( "1", "M", cldr ), date1 );
-	deepEqual( parse( "1", "L", cldr ), date1 );
+	assert.deepEqual( parse( "1", "M", cldr ), date1 );
+	assert.deepEqual( parse( "1", "L", cldr ), date1 );
 });
 
-test( "should parse month (MM|LL) with padding", function() {
+QUnit.test( "should parse month (MM|LL) with padding", function( assert ) {
 	date1 = new Date();
 	date1.setMonth( 0 );
 	date1 = startOf( date1, "month" );
-	deepEqual( parse( "01", "MM", cldr ), date1 );
-	deepEqual( parse( "01", "LL", cldr ), date1 );
+	assert.deepEqual( parse( "01", "MM", cldr ), date1 );
+	assert.deepEqual( parse( "01", "LL", cldr ), date1 );
 });
 
-test( "should parse month (MMM|LLL)", function() {
+QUnit.test( "should parse month (MMM|LLL)", function( assert ) {
 	date1 = new Date();
 	date1.setMonth( 0 );
 	date1 = startOf( date1, "month" );
-	deepEqual( parse( "Jan", "MMM", cldr ), date1 );
-	deepEqual( parse( "Jan", "LLL", cldr ), date1 );
+	assert.deepEqual( parse( "Jan", "MMM", cldr ), date1 );
+	assert.deepEqual( parse( "Jan", "LLL", cldr ), date1 );
 });
 
-test( "should parse month (MMMM|LLLL)", function() {
+QUnit.test( "should parse month (MMMM|LLLL)", function( assert ) {
 	date1 = new Date();
 	date1.setMonth( 0 );
 	date1 = startOf( date1, "month" );
-	deepEqual( parse( "January", "MMMM", cldr ), date1 );
-	deepEqual( parse( "January", "LLLL", cldr ), date1 );
+	assert.deepEqual( parse( "January", "MMMM", cldr ), date1 );
+	assert.deepEqual( parse( "January", "LLLL", cldr ), date1 );
 });
 
-test( "should parse month (MMMMM|LLLLL)", function() {
+QUnit.test( "should parse month (MMMMM|LLLLL)", function( assert ) {
 	date1 = new Date();
 	date1.setMonth( 0 );
 	date1 = startOf( date1, "month" );
-	deepEqual( parse( "J", "MMMMM", cldr ), date1 );
-	deepEqual( parse( "J", "LLLLL", cldr ), date1 );
+	assert.deepEqual( parse( "J", "MMMMM", cldr ), date1 );
+	assert.deepEqual( parse( "J", "LLLLL", cldr ), date1 );
 });
 
 /**
  *  Day
  */
 
-test( "should parse day (d) with no padding", function() {
+QUnit.test( "should parse day (d) with no padding", function( assert ) {
 	date1 = new Date();
 	date1.setDate( 2 );
 	date1 = startOf( date1, "day" );
-	deepEqual( parse( "2", "d", cldr ), date1 );
+	assert.deepEqual( parse( "2", "d", cldr ), date1 );
 });
 
-test( "should parse day (dd) with padding", function() {
+QUnit.test( "should parse day (dd) with padding", function( assert ) {
 	date1 = new Date();
 	date1.setDate( 2 );
 	date1 = startOf( date1, "day" );
-	deepEqual( parse( "02", "dd", cldr ), date1 );
+	assert.deepEqual( parse( "02", "dd", cldr ), date1 );
 });
 
-test( "should parse day of year (D) with no padding", function() {
+QUnit.test( "should parse day of year (D) with no padding", function( assert ) {
 	date1 = new Date();
 	date1.setMonth( 0 );
 	date1.setDate( 2 );
 	date1 = startOf( date1, "day" );
-	deepEqual( parse( "2", "D", cldr ), date1 );
+	assert.deepEqual( parse( "2", "D", cldr ), date1 );
 });
 
-test( "should parse day of year (DD|DDD) with padding", function() {
+QUnit.test( "should parse day of year (DD|DDD) with padding", function( assert ) {
 	date1 = new Date();
 	date1.setMonth( 0 );
 	date1.setDate( 2 );
 	date1 = startOf( date1, "day" );
-	deepEqual( parse( "02", "DD", cldr ), date1 );
-	deepEqual( parse( "002", "DDD", cldr ), date1 );
+	assert.deepEqual( parse( "02", "DD", cldr ), date1 );
+	assert.deepEqual( parse( "002", "DDD", cldr ), date1 );
 });
 
 /**
  *  Period
  */
 
-test( "should parse period (a)", function() {
+QUnit.test( "should parse period (a)", function( assert ) {
 	date1 = new Date();
 	date2 = new Date();
 	date1.setHours( 5 );
 	date2.setHours( 17 );
 	date1 = startOf( date1, "hour" );
 	date2 = startOf( date2, "hour" );
-	deepEqual( parse( "5 AM", "h a", cldr ), date1 );
-	deepEqual( parse( "5 PM", "h a", cldr ), date2 );
+	assert.deepEqual( parse( "5 AM", "h a", cldr ), date1 );
+	assert.deepEqual( parse( "5 PM", "h a", cldr ), date2 );
 });
 
 /**
  *  Hour
  */
 
-test( "should parse hour (h) using 12-hour-cycle [1-12] with no padding", function() {
+QUnit.test( "should parse hour (h) using 12-hour-cycle [1-12] with no padding", function( assert ) {
 	date1 = new Date();
 	date1.setHours( 9 );
 	date1 = startOf( date1, "hour" );
-	deepEqual( parse( "9", "h", cldr ), date1 );
+	assert.deepEqual( parse( "9", "h", cldr ), date1 );
 });
 
-test( "should parse hour (hh) using 12-hour-cycle [1-12] with padding", function() {
+QUnit.test( "should parse hour (hh) using 12-hour-cycle [1-12] with padding", function( assert ) {
 	date1 = new Date();
 	date1.setHours( 9 );
 	date1 = startOf( date1, "hour" );
-	deepEqual( parse( "09", "hh", cldr ), date1 );
+	assert.deepEqual( parse( "09", "hh", cldr ), date1 );
 });
 
-test( "should parse hour (H) using 24-hour-cycle [0-23] with no padding", function() {
+QUnit.test( "should parse hour (H) using 24-hour-cycle [0-23] with no padding", function( assert ) {
 	date1 = new Date();
 	date1.setHours( 17 );
 	date1 = startOf( date1, "hour" );
-	deepEqual( parse( "16", "H", cldr ), date1 );
+	assert.deepEqual( parse( "16", "H", cldr ), date1 );
 });
 
-test( "should parse hour (HH) using 24-hour-cycle [0-23] with padding", function() {
+QUnit.test( "should parse hour (HH) using 24-hour-cycle [0-23] with padding", function( assert ) {
 	date1 = new Date();
 	date1.setHours( 17 );
 	date1 = startOf( date1, "hour" );
-	deepEqual( parse( "16", "HH", cldr ), date1 );
+	assert.deepEqual( parse( "16", "HH", cldr ), date1 );
 });
 
-test( "should parse hour (K) using 12-hour-cycle [0-11] with no padding", function() {
+QUnit.test( "should parse hour (K) using 12-hour-cycle [0-11] with no padding", function( assert ) {
 	date1 = new Date();
 	date1.setHours( 9 );
 	date1 = startOf( date1, "hour" );
-	deepEqual( parse( "8", "K", cldr ), date1 );
+	assert.deepEqual( parse( "8", "K", cldr ), date1 );
 });
 
-test( "should parse hour (KK) using 12-hour-cycle [0-11] with padding", function() {
+QUnit.test( "should parse hour (KK) using 12-hour-cycle [0-11] with padding", function( assert ) {
 	date1 = new Date();
 	date1.setHours( 9 );
 	date1 = startOf( date1, "hour" );
-	deepEqual( parse( "08", "KK", cldr ), date1 );
+	assert.deepEqual( parse( "08", "KK", cldr ), date1 );
 });
 
-test( "should parse hour (k) using 24-hour-cycle [1-24] with no padding", function() {
+QUnit.test( "should parse hour (k) using 24-hour-cycle [1-24] with no padding", function( assert ) {
 	date1 = new Date();
 	date1.setHours( 17 );
 	date1 = startOf( date1, "hour" );
-	deepEqual( parse( "17", "k", cldr ), date1 );
+	assert.deepEqual( parse( "17", "k", cldr ), date1 );
 });
 
-test( "should parse hour (kk) using 24-hour-cycle [1-24] with padding", function() {
+QUnit.test( "should parse hour (kk) using 24-hour-cycle [1-24] with padding", function( assert ) {
 	date1 = new Date();
 	date1.setHours( 17 );
 	date1 = startOf( date1, "hour" );
-	deepEqual( parse( "17", "kk", cldr ), date1 );
+	assert.deepEqual( parse( "17", "kk", cldr ), date1 );
 });
 
-test( "should parse hour (j) using preferred hour format for the locale (h, H, K, or k) with no padding", function() {
+QUnit.test( "should parse hour (j) using preferred hour format for the locale (h, H, K, or k) with no padding", function( assert ) {
 	date1 = new Date();
 	date1.setHours( 9 );
 	date1 = startOf( date1, "hour" );
-	deepEqual( parse( "9", "j", cldr ), date1 );
+	assert.deepEqual( parse( "9", "j", cldr ), date1 );
 });
 
-test( "should parse hour (jj) using preferred hour format for the locale (h, H, K, or k) with padding", function() {
+QUnit.test( "should parse hour (jj) using preferred hour format for the locale (h, H, K, or k) with padding", function( assert ) {
 	date1 = new Date();
 	date1.setHours( 9 );
 	date1 = startOf( date1, "hour" );
-	deepEqual( parse( "09", "jj", cldr ), date1 );
+	assert.deepEqual( parse( "09", "jj", cldr ), date1 );
 });
 
 /**
  *  Minute
  */
 
-test( "should parse minute (m) with no padding", function() {
+QUnit.test( "should parse minute (m) with no padding", function( assert ) {
 	date1 = new Date();
 	date1.setMinutes( 5 );
 	date1 = startOf( date1, "minute" );
-	deepEqual( parse( "5", "m", cldr ), date1 );
+	assert.deepEqual( parse( "5", "m", cldr ), date1 );
 });
 
-test( "should parse minute (mm) with padding", function() {
+QUnit.test( "should parse minute (mm) with padding", function( assert ) {
 	date1 = new Date();
 	date1.setMinutes( 5 );
 	date1 = startOf( date1, "minute" );
-	deepEqual( parse( "05", "mm", cldr ), date1 );
+	assert.deepEqual( parse( "05", "mm", cldr ), date1 );
 });
 
 /**
  *  Second
  */
 
-test( "should parse second (s) with no padding", function() {
+QUnit.test( "should parse second (s) with no padding", function( assert ) {
 	date1 = new Date();
 	date1.setSeconds( 59 );
 	date1 = startOf( date1, "second" );
-	deepEqual( parse( "59", "s", cldr ), date1 );
+	assert.deepEqual( parse( "59", "s", cldr ), date1 );
 });
 
-test( "should parse second (ss) with padding", function() {
+QUnit.test( "should parse second (ss) with padding", function( assert ) {
 	date1 = new Date();
 	date1.setSeconds( 59 );
 	date1 = startOf( date1, "second" );
-	deepEqual( parse( "59", "ss", cldr ), date1 );
+	assert.deepEqual( parse( "59", "ss", cldr ), date1 );
 });
 
-test( "should parse milliseconds (S+)", function() {
+QUnit.test( "should parse milliseconds (S+)", function( assert ) {
 	date1 = new Date();
 	date1.setSeconds( 0 );
 	date1.setMilliseconds( 400 );
-	deepEqual( parse( "0 4", "s S", cldr ), date1 );
+	assert.deepEqual( parse( "0 4", "s S", cldr ), date1 );
 	date1.setMilliseconds( 370 );
-	deepEqual( parse( "0 37", "s SS", cldr ), date1 );
+	assert.deepEqual( parse( "0 37", "s SS", cldr ), date1 );
 	date1.setMilliseconds( 369 );
-	deepEqual( parse( "0 369", "s SSS", cldr ), date1 );
-	deepEqual( parse( "0 3690", "s SSSS", cldr ), date1 );
-	deepEqual( parse( "0 36900", "s SSSSS", cldr ), date1 );
+	assert.deepEqual( parse( "0 369", "s SSS", cldr ), date1 );
+	assert.deepEqual( parse( "0 3690", "s SSSS", cldr ), date1 );
+	assert.deepEqual( parse( "0 36900", "s SSSSS", cldr ), date1 );
 });
 
-test( "should parse milliseconds in a day (A+)", function() {
+QUnit.test( "should parse milliseconds in a day (A+)", function( assert ) {
 	date1 = new Date();
 	date1 = startOf( date1, "day" );
 	date1.setMilliseconds( 63307400 );
-	deepEqual( parse( "633074", "A", cldr ), date1 );
+	assert.deepEqual( parse( "633074", "A", cldr ), date1 );
 	date1 = startOf( date1, "day" );
 	date1.setMilliseconds( 63307370 );
-	deepEqual( parse( "6330737", "AA", cldr ), date1 );
+	assert.deepEqual( parse( "6330737", "AA", cldr ), date1 );
 	date1 = startOf( date1, "day" );
 	date1.setMilliseconds( 63307369 );
-	deepEqual( parse( "63307369", "AAA", cldr ), date1 );
-	deepEqual( parse( "633073690", "AAAA", cldr ), date1 );
-	deepEqual( parse( "6330736900", "AAAAA", cldr ), date1 );
+	assert.deepEqual( parse( "63307369", "AAA", cldr ), date1 );
+	assert.deepEqual( parse( "633073690", "AAAA", cldr ), date1 );
+	assert.deepEqual( parse( "6330736900", "AAAAA", cldr ), date1 );
 });
 
 /**

--- a/test/unit/date/tokenizer.js
+++ b/test/unit/date/tokenizer.js
@@ -16,40 +16,40 @@ Cldr.load( weekData );
 
 cldr = new Cldr( "en" );
 
-module( "Datetime Tokenizer" );
+QUnit.module( "Datetime Tokenizer" );
 
 /**
  *  Era
  */
 
-test( "should tokenize era (G|GG|GGG)", function() {
-	deepEqual( tokenizer( "AD", "G", cldr ), [{
+QUnit.test( "should tokenize era (G|GG|GGG)", function( assert ) {
+	assert.deepEqual( tokenizer( "AD", "G", cldr ), [{
 		type: "G",
 		lexeme: "AD",
 		value: "1"
 	}] );
-	deepEqual( tokenizer( "AD", "GG", cldr ), [{
+	assert.deepEqual( tokenizer( "AD", "GG", cldr ), [{
 		type: "GG",
 		lexeme: "AD",
 		value: "1"
 	}] );
-	deepEqual( tokenizer( "AD", "GGG", cldr ), [{
+	assert.deepEqual( tokenizer( "AD", "GGG", cldr ), [{
 		type: "GGG",
 		lexeme: "AD",
 		value: "1"
 	}] );
 });
 
-test( "should tokenize era (GGGG)", function() {
-	deepEqual( tokenizer( "Anno Domini", "GGGG", cldr ), [{
+QUnit.test( "should tokenize era (GGGG)", function( assert ) {
+	assert.deepEqual( tokenizer( "Anno Domini", "GGGG", cldr ), [{
 		type: "GGGG",
 		lexeme: "Anno Domini",
 		value: "1"
 	}] );
 });
 
-test( "should tokenize era (GGGGG)", function() {
-	deepEqual( tokenizer( "A", "GGGGG", cldr ), [{
+QUnit.test( "should tokenize era (GGGGG)", function( assert ) {
+	assert.deepEqual( tokenizer( "A", "GGGGG", cldr ), [{
 		type: "GGGGG",
 		lexeme: "A",
 		value: "1"
@@ -60,51 +60,51 @@ test( "should tokenize era (GGGGG)", function() {
  *  Year
  */
 
-test( "should tokenize year (y) with no padding", function() {
-	deepEqual( tokenizer( "1982", "y", cldr ), [{
+QUnit.test( "should tokenize year (y) with no padding", function( assert ) {
+	assert.deepEqual( tokenizer( "1982", "y", cldr ), [{
 		type: "y",
 		lexeme: "1982"
 	}] );
 });
 
-test( "should tokenize year (yy) with padding, and limit 2 digits", function() {
-	deepEqual( tokenizer( "82", "yy", cldr ), [{
+QUnit.test( "should tokenize year (yy) with padding, and limit 2 digits", function( assert ) {
+	assert.deepEqual( tokenizer( "82", "yy", cldr ), [{
 		type: "yy",
 		lexeme: "82"
 	}] );
 });
 
-test( "should tokenize year (yyy+) with padding", function() {
-	deepEqual( tokenizer( "1982", "yyy", cldr ), [{
+QUnit.test( "should tokenize year (yyy+) with padding", function( assert ) {
+	assert.deepEqual( tokenizer( "1982", "yyy", cldr ), [{
 		type: "yyy",
 		lexeme: "1982"
 	}] );
-	deepEqual( tokenizer( "01982", "yyyyy", cldr ), [{
+	assert.deepEqual( tokenizer( "01982", "yyyyy", cldr ), [{
 		type: "yyyyy",
 		lexeme: "01982"
 	}] );
 });
 
-test( "should tokenize year in \"week of year\" (Y) with no padding", function() {
-	deepEqual( tokenizer( "1982", "Y", cldr ), [{
+QUnit.test( "should tokenize year in \"week of year\" (Y) with no padding", function( assert ) {
+	assert.deepEqual( tokenizer( "1982", "Y", cldr ), [{
 		type: "Y",
 		lexeme: "1982"
 	}] );
 });
 
-test( "should tokenize year in \"week of year\" (YY) with padding, and limit 2 digits", function() {
-	deepEqual( tokenizer( "82", "YY", cldr ), [{
+QUnit.test( "should tokenize year in \"week of year\" (YY) with padding, and limit 2 digits", function( assert ) {
+	assert.deepEqual( tokenizer( "82", "YY", cldr ), [{
 		type: "YY",
 		lexeme: "82"
 	}] );
 });
 
-test( "should tokenize year in \"week of year\" (YYY+) with padding", function() {
-	deepEqual( tokenizer( "1982", "YYY", cldr ), [{
+QUnit.test( "should tokenize year in \"week of year\" (YYY+) with padding", function( assert ) {
+	assert.deepEqual( tokenizer( "1982", "YYY", cldr ), [{
 		type: "YYY",
 		lexeme: "1982"
 	}] );
-	deepEqual( tokenizer( "01982", "YYYYY", cldr ), [{
+	assert.deepEqual( tokenizer( "01982", "YYYYY", cldr ), [{
 		type: "YYYYY",
 		lexeme: "01982"
 	}] );
@@ -114,48 +114,48 @@ test( "should tokenize year in \"week of year\" (YYY+) with padding", function()
  *  Quarter
  */
 
-test( "should tokenize quarter (Q|q) with no padding", function() {
-	deepEqual( tokenizer( "1", "Q", cldr ), [{
+QUnit.test( "should tokenize quarter (Q|q) with no padding", function( assert ) {
+	assert.deepEqual( tokenizer( "1", "Q", cldr ), [{
 		type: "Q",
 		lexeme: "1"
 	}] );
-	deepEqual( tokenizer( "1", "q", cldr ), [{
+	assert.deepEqual( tokenizer( "1", "q", cldr ), [{
 		type: "q",
 		lexeme: "1"
 	}] );
 });
 
-test( "should tokenize quarter (QQ|qq) with padding", function() {
-	deepEqual( tokenizer( "01", "QQ", cldr ), [{
+QUnit.test( "should tokenize quarter (QQ|qq) with padding", function( assert ) {
+	assert.deepEqual( tokenizer( "01", "QQ", cldr ), [{
 		type: "QQ",
 		lexeme: "01"
 	}] );
-	deepEqual( tokenizer( "01", "qq", cldr ), [{
+	assert.deepEqual( tokenizer( "01", "qq", cldr ), [{
 		type: "qq",
 		lexeme: "01"
 	}] );
 });
 
-test( "should tokenize quarter (QQQ|qqq)", function() {
-	deepEqual( tokenizer( "Q1", "QQQ", cldr ), [{
+QUnit.test( "should tokenize quarter (QQQ|qqq)", function( assert ) {
+	assert.deepEqual( tokenizer( "Q1", "QQQ", cldr ), [{
 		type: "QQQ",
 		lexeme: "Q1",
 		value: "1"
 	}] );
-	deepEqual( tokenizer( "Q1", "qqq", cldr ), [{
+	assert.deepEqual( tokenizer( "Q1", "qqq", cldr ), [{
 		type: "qqq",
 		lexeme: "Q1",
 		value: "1"
 	}] );
 });
 
-test( "should tokenize quarter (QQQQ|qqqq) with padding", function() {
-	deepEqual( tokenizer( "1st quarter", "QQQQ", cldr ), [{
+QUnit.test( "should tokenize quarter (QQQQ|qqqq) with padding", function( assert ) {
+	assert.deepEqual( tokenizer( "1st quarter", "QQQQ", cldr ), [{
 		type: "QQQQ",
 		lexeme: "1st quarter",
 		value: "1"
 	}] );
-	deepEqual( tokenizer( "1st quarter", "qqqq", cldr ), [{
+	assert.deepEqual( tokenizer( "1st quarter", "qqqq", cldr ), [{
 		type: "qqqq",
 		lexeme: "1st quarter",
 		value: "1"
@@ -166,61 +166,61 @@ test( "should tokenize quarter (QQQQ|qqqq) with padding", function() {
  *  Month
  */
 
-test( "should tokenize month (M|L) with no padding", function() {
-	deepEqual( tokenizer( "1", "M", cldr ), [{
+QUnit.test( "should tokenize month (M|L) with no padding", function( assert ) {
+	assert.deepEqual( tokenizer( "1", "M", cldr ), [{
 		type: "M",
 		lexeme: "1"
 	}] );
-	deepEqual( tokenizer( "1", "L", cldr ), [{
+	assert.deepEqual( tokenizer( "1", "L", cldr ), [{
 		type: "L",
 		lexeme: "1"
 	}] );
 });
 
-test( "should tokenize month (MM|LL) with padding", function() {
-	deepEqual( tokenizer( "01", "MM", cldr ), [{
+QUnit.test( "should tokenize month (MM|LL) with padding", function( assert ) {
+	assert.deepEqual( tokenizer( "01", "MM", cldr ), [{
 		type: "MM",
 		lexeme: "01"
 	}] );
-	deepEqual( tokenizer( "01", "LL", cldr ), [{
+	assert.deepEqual( tokenizer( "01", "LL", cldr ), [{
 		type: "LL",
 		lexeme: "01"
 	}] );
 });
 
-test( "should tokenize month (MMM|LLL)", function() {
-	deepEqual( tokenizer( "Jan", "MMM", cldr ), [{
+QUnit.test( "should tokenize month (MMM|LLL)", function( assert ) {
+	assert.deepEqual( tokenizer( "Jan", "MMM", cldr ), [{
 		type: "MMM",
 		lexeme: "Jan",
 		value: "1"
 	}] );
-	deepEqual( tokenizer( "Jan", "LLL", cldr ), [{
+	assert.deepEqual( tokenizer( "Jan", "LLL", cldr ), [{
 		type: "LLL",
 		lexeme: "Jan",
 		value: "1"
 	}] );
 });
 
-test( "should tokenize month (MMMM|LLLL)", function() {
-	deepEqual( tokenizer( "January", "MMMM", cldr ), [{
+QUnit.test( "should tokenize month (MMMM|LLLL)", function( assert ) {
+	assert.deepEqual( tokenizer( "January", "MMMM", cldr ), [{
 		type: "MMMM",
 		lexeme: "January",
 		value: "1"
 	}] );
-	deepEqual( tokenizer( "January", "LLLL", cldr ), [{
+	assert.deepEqual( tokenizer( "January", "LLLL", cldr ), [{
 		type: "LLLL",
 		lexeme: "January",
 		value: "1"
 	}] );
 });
 
-test( "should tokenize month (MMMMM|LLLLL)", function() {
-	deepEqual( tokenizer( "J", "MMMMM", cldr ), [{
+QUnit.test( "should tokenize month (MMMMM|LLLLL)", function( assert ) {
+	assert.deepEqual( tokenizer( "J", "MMMMM", cldr ), [{
 		type: "MMMMM",
 		lexeme: "J",
 		value: "1"
 	}] );
-	deepEqual( tokenizer( "J", "LLLLL", cldr ), [{
+	assert.deepEqual( tokenizer( "J", "LLLLL", cldr ), [{
 		type: "LLLLL",
 		lexeme: "J",
 		value: "1"
@@ -231,22 +231,22 @@ test( "should tokenize month (MMMMM|LLLLL)", function() {
  *  Week
  */
 
-test( "should tokenize week of year (w) with no padding", function() {
-	deepEqual( tokenizer( "1", "w", cldr ), [{
+QUnit.test( "should tokenize week of year (w) with no padding", function( assert ) {
+	assert.deepEqual( tokenizer( "1", "w", cldr ), [{
 		type: "w",
 		lexeme: "1"
 	}] );
 });
 
-test( "should tokenize week of year (ww) with padding", function() {
-	deepEqual( tokenizer( "01", "ww", cldr ), [{
+QUnit.test( "should tokenize week of year (ww) with padding", function( assert ) {
+	assert.deepEqual( tokenizer( "01", "ww", cldr ), [{
 		type: "ww",
 		lexeme: "01"
 	}] );
 });
 
-test( "should tokenize week of month (W)", function() {
-	deepEqual( tokenizer( "1", "W", cldr ), [{
+QUnit.test( "should tokenize week of month (W)", function( assert ) {
+	assert.deepEqual( tokenizer( "1", "W", cldr ), [{
 		type: "W",
 		lexeme: "1"
 	}] );
@@ -256,40 +256,40 @@ test( "should tokenize week of month (W)", function() {
  *  Day
  */
 
-test( "should tokenize day (d) with no padding", function() {
-	deepEqual( tokenizer( "2", "d", cldr ), [{
+QUnit.test( "should tokenize day (d) with no padding", function( assert ) {
+	assert.deepEqual( tokenizer( "2", "d", cldr ), [{
 		type: "d",
 		lexeme: "2"
 	}] );
 });
 
-test( "should tokenize day (dd) with padding", function() {
-	deepEqual( tokenizer( "02", "dd", cldr ), [{
+QUnit.test( "should tokenize day (dd) with padding", function( assert ) {
+	assert.deepEqual( tokenizer( "02", "dd", cldr ), [{
 		type: "dd",
 		lexeme: "02"
 	}] );
 });
 
-test( "should tokenize day of year (D) with no padding", function() {
-	deepEqual( tokenizer( "2", "D", cldr ), [{
+QUnit.test( "should tokenize day of year (D) with no padding", function( assert ) {
+	assert.deepEqual( tokenizer( "2", "D", cldr ), [{
 		type: "D",
 		lexeme: "2"
 	}] );
 });
 
-test( "should tokenize day of year (DD|DDD) with padding", function() {
-	deepEqual( tokenizer( "02", "DD", cldr ), [{
+QUnit.test( "should tokenize day of year (DD|DDD) with padding", function( assert ) {
+	assert.deepEqual( tokenizer( "02", "DD", cldr ), [{
 		type: "DD",
 		lexeme: "02"
 	}] );
-	deepEqual( tokenizer( "002", "DDD", cldr ), [{
+	assert.deepEqual( tokenizer( "002", "DDD", cldr ), [{
 		type: "DDD",
 		lexeme: "002"
 	}] );
 });
 
-test( "should tokenize day of week in month (F)", function() {
-	deepEqual( tokenizer( "1", "F", cldr ), [{
+QUnit.test( "should tokenize day of week in month (F)", function( assert ) {
+	assert.deepEqual( tokenizer( "1", "F", cldr ), [{
 		type: "F",
 		lexeme: "1"
 	}] );
@@ -299,105 +299,105 @@ test( "should tokenize day of week in month (F)", function() {
  *  Week day
  */
 
-test( "should tokenize local day of week (e|c) with no padding", function() {
-	deepEqual( tokenizer( "7", "e", cldr ), [{
+QUnit.test( "should tokenize local day of week (e|c) with no padding", function( assert ) {
+	assert.deepEqual( tokenizer( "7", "e", cldr ), [{
 		type: "e",
 		lexeme: "7"
 	}] );
-	deepEqual( tokenizer( "7", "c", cldr ), [{
+	assert.deepEqual( tokenizer( "7", "c", cldr ), [{
 		type: "c",
 		lexeme: "7"
 	}] );
 });
 
-test( "should tokenize local day of week (ee|cc) with padding", function() {
-	deepEqual( tokenizer( "07", "ee", cldr ), [{
+QUnit.test( "should tokenize local day of week (ee|cc) with padding", function( assert ) {
+	assert.deepEqual( tokenizer( "07", "ee", cldr ), [{
 		type: "ee",
 		lexeme: "07"
 	}] );
-	deepEqual( tokenizer( "07", "cc", cldr ), [{
+	assert.deepEqual( tokenizer( "07", "cc", cldr ), [{
 		type: "cc",
 		lexeme: "07"
 	}] );
 });
 
-test( "should tokenize local day of week (E|EE|EEE|eee|ccc)", function() {
-	deepEqual( tokenizer( "Sat", "E", cldr ), [{
+QUnit.test( "should tokenize local day of week (E|EE|EEE|eee|ccc)", function( assert ) {
+	assert.deepEqual( tokenizer( "Sat", "E", cldr ), [{
 		type: "E",
 		lexeme: "Sat",
 		value: "sat"
 	}] );
-	deepEqual( tokenizer( "Sat", "EE", cldr ), [{
+	assert.deepEqual( tokenizer( "Sat", "EE", cldr ), [{
 		type: "EE",
 		lexeme: "Sat",
 		value: "sat"
 	}] );
-	deepEqual( tokenizer( "Sat", "EEE", cldr ), [{
+	assert.deepEqual( tokenizer( "Sat", "EEE", cldr ), [{
 		type: "EEE",
 		lexeme: "Sat",
 		value: "sat"
 	}] );
-	deepEqual( tokenizer( "Sat", "eee", cldr ), [{
+	assert.deepEqual( tokenizer( "Sat", "eee", cldr ), [{
 		type: "eee",
 		lexeme: "Sat",
 		value: "sat"
 	}] );
-	deepEqual( tokenizer( "Sat", "ccc", cldr ), [{
+	assert.deepEqual( tokenizer( "Sat", "ccc", cldr ), [{
 		type: "ccc",
 		lexeme: "Sat",
 		value: "sat"
 	}] );
 });
 
-test( "should tokenize local day of week (EEEE|eeee|cccc)", function() {
-	deepEqual( tokenizer( "Saturday", "EEEE", cldr ), [{
+QUnit.test( "should tokenize local day of week (EEEE|eeee|cccc)", function( assert ) {
+	assert.deepEqual( tokenizer( "Saturday", "EEEE", cldr ), [{
 		type: "EEEE",
 		lexeme: "Saturday",
 		value: "sat"
 	}] );
-	deepEqual( tokenizer( "Saturday", "eeee", cldr ), [{
+	assert.deepEqual( tokenizer( "Saturday", "eeee", cldr ), [{
 		type: "eeee",
 		lexeme: "Saturday",
 		value: "sat"
 	}] );
-	deepEqual( tokenizer( "Saturday", "cccc", cldr ), [{
+	assert.deepEqual( tokenizer( "Saturday", "cccc", cldr ), [{
 		type: "cccc",
 		lexeme: "Saturday",
 		value: "sat"
 	}] );
 });
 
-test( "should tokenize local day of week (EEEEE|eeeee|ccccc)", function() {
+QUnit.test( "should tokenize local day of week (EEEEE|eeeee|ccccc)", function( assert ) {
 	// OBS: note the abbreviated S would matche sun or sat. But, only the first is returned.
-	deepEqual( tokenizer( "S", "EEEEE", cldr ), [{
+	assert.deepEqual( tokenizer( "S", "EEEEE", cldr ), [{
 		type: "EEEEE",
 		lexeme: "S",
 		value: "sun"
 	}] );
-	deepEqual( tokenizer( "S", "eeeee", cldr ), [{
+	assert.deepEqual( tokenizer( "S", "eeeee", cldr ), [{
 		type: "eeeee",
 		lexeme: "S",
 		value: "sun"
 	}] );
-	deepEqual( tokenizer( "S", "ccccc", cldr ), [{
+	assert.deepEqual( tokenizer( "S", "ccccc", cldr ), [{
 		type: "ccccc",
 		lexeme: "S",
 		value: "sun"
 	}] );
 });
 
-test( "should tokenize local day of week (EEEEEE|eeeeee|cccccc)", function() {
-	deepEqual( tokenizer( "Sa", "EEEEEE", cldr ), [{
+QUnit.test( "should tokenize local day of week (EEEEEE|eeeeee|cccccc)", function( assert ) {
+	assert.deepEqual( tokenizer( "Sa", "EEEEEE", cldr ), [{
 		type: "EEEEEE",
 		lexeme: "Sa",
 		value: "sat"
 	}] );
-	deepEqual( tokenizer( "Sa", "eeeeee", cldr ), [{
+	assert.deepEqual( tokenizer( "Sa", "eeeeee", cldr ), [{
 		type: "eeeeee",
 		lexeme: "Sa",
 		value: "sat"
 	}] );
-	deepEqual( tokenizer( "Sa", "cccccc", cldr ), [{
+	assert.deepEqual( tokenizer( "Sa", "cccccc", cldr ), [{
 		type: "cccccc",
 		lexeme: "Sa",
 		value: "sat"
@@ -408,8 +408,8 @@ test( "should tokenize local day of week (EEEEEE|eeeeee|cccccc)", function() {
  *  Period
  */
 
-test( "should tokenize period (a)", function() {
-	deepEqual( tokenizer( "AM", "a", cldr ), [{
+QUnit.test( "should tokenize period (a)", function( assert ) {
+	assert.deepEqual( tokenizer( "AM", "a", cldr ), [{
 		type: "a",
 		lexeme: "AM",
 		value: "am"
@@ -420,71 +420,71 @@ test( "should tokenize period (a)", function() {
  *  Hour
  */
 
-test( "should tokenize hour (h) using 12-hour-cycle [1-12] with no padding", function() {
-	deepEqual( tokenizer( "9", "h", cldr ), [{
+QUnit.test( "should tokenize hour (h) using 12-hour-cycle [1-12] with no padding", function( assert ) {
+	assert.deepEqual( tokenizer( "9", "h", cldr ), [{
 		type: "h",
 		lexeme: "9"
 	}] );
 });
 
-test( "should tokenize hour (hh) using 12-hour-cycle [1-12] with padding", function() {
-	deepEqual( tokenizer( "09", "hh", cldr ), [{
+QUnit.test( "should tokenize hour (hh) using 12-hour-cycle [1-12] with padding", function( assert ) {
+	assert.deepEqual( tokenizer( "09", "hh", cldr ), [{
 		type: "hh",
 		lexeme: "09"
 	}] );
 });
 
-test( "should tokenize hour (H) using 24-hour-cycle [0-23] with no padding", function() {
-	deepEqual( tokenizer( "9", "H", cldr ), [{
+QUnit.test( "should tokenize hour (H) using 24-hour-cycle [0-23] with no padding", function( assert ) {
+	assert.deepEqual( tokenizer( "9", "H", cldr ), [{
 		type: "H",
 		lexeme: "9"
 	}] );
 });
 
-test( "should tokenize hour (HH) using 24-hour-cycle [0-23] with padding", function() {
-	deepEqual( tokenizer( "09", "HH", cldr ), [{
+QUnit.test( "should tokenize hour (HH) using 24-hour-cycle [0-23] with padding", function( assert ) {
+	assert.deepEqual( tokenizer( "09", "HH", cldr ), [{
 		type: "HH",
 		lexeme: "09"
 	}] );
 });
 
-test( "should tokenize hour (K) using 12-hour-cycle [0-11] with no padding", function() {
-	deepEqual( tokenizer( "9", "K", cldr ), [{
+QUnit.test( "should tokenize hour (K) using 12-hour-cycle [0-11] with no padding", function( assert ) {
+	assert.deepEqual( tokenizer( "9", "K", cldr ), [{
 		type: "K",
 		lexeme: "9"
 	}] );
 });
 
-test( "should tokenize hour (KK) using 12-hour-cycle [0-11] with padding", function() {
-	deepEqual( tokenizer( "09", "KK", cldr ), [{
+QUnit.test( "should tokenize hour (KK) using 12-hour-cycle [0-11] with padding", function( assert ) {
+	assert.deepEqual( tokenizer( "09", "KK", cldr ), [{
 		type: "KK",
 		lexeme: "09"
 	}] );
 });
 
-test( "should tokenize hour (k) using 24-hour-cycle [1-24] with no padding", function() {
-	deepEqual( tokenizer( "9", "k", cldr ), [{
+QUnit.test( "should tokenize hour (k) using 24-hour-cycle [1-24] with no padding", function( assert ) {
+	assert.deepEqual( tokenizer( "9", "k", cldr ), [{
 		type: "k",
 		lexeme: "9"
 	}] );
 });
 
-test( "should tokenize hour (kk) using 24-hour-cycle [1-24] with padding", function() {
-	deepEqual( tokenizer( "09", "kk", cldr ), [{
+QUnit.test( "should tokenize hour (kk) using 24-hour-cycle [1-24] with padding", function( assert ) {
+	assert.deepEqual( tokenizer( "09", "kk", cldr ), [{
 		type: "kk",
 		lexeme: "09"
 	}] );
 });
 
-test( "should tokenize hour (j) using preferred hour format for the locale (h, H, K, or k) with no padding", function() {
-	deepEqual( tokenizer( "9", "j", cldr ), [{
+QUnit.test( "should tokenize hour (j) using preferred hour format for the locale (h, H, K, or k) with no padding", function( assert ) {
+	assert.deepEqual( tokenizer( "9", "j", cldr ), [{
 		type: "j",
 		lexeme: "9"
 	}] );
 });
 
-test( "should tokenize hour (jj) using preferred hour format for the locale (h, H, K, or k) with padding", function() {
-	deepEqual( tokenizer( "09", "jj", cldr ), [{
+QUnit.test( "should tokenize hour (jj) using preferred hour format for the locale (h, H, K, or k) with padding", function( assert ) {
+	assert.deepEqual( tokenizer( "09", "jj", cldr ), [{
 		type: "jj",
 		lexeme: "09"
 	}] );
@@ -494,15 +494,15 @@ test( "should tokenize hour (jj) using preferred hour format for the locale (h, 
  *  Minute
  */
 
-test( "should tokenize minute (m) with no padding", function() {
-	deepEqual( tokenizer( "5", "m", cldr ), [{
+QUnit.test( "should tokenize minute (m) with no padding", function( assert ) {
+	assert.deepEqual( tokenizer( "5", "m", cldr ), [{
 		type: "m",
 		lexeme: "5"
 	}] );
 });
 
-test( "should tokenize minute (mm) with padding", function() {
-	deepEqual( tokenizer( "05", "mm", cldr ), [{
+QUnit.test( "should tokenize minute (mm) with padding", function( assert ) {
+	assert.deepEqual( tokenizer( "05", "mm", cldr ), [{
 		type: "mm",
 		lexeme: "05"
 	}] );
@@ -512,61 +512,61 @@ test( "should tokenize minute (mm) with padding", function() {
  *  Second
  */
 
-test( "should tokenize second (s) with no padding", function() {
-	deepEqual( tokenizer( "59", "s", cldr ), [{
+QUnit.test( "should tokenize second (s) with no padding", function( assert ) {
+	assert.deepEqual( tokenizer( "59", "s", cldr ), [{
 		type: "s",
 		lexeme: "59"
 	}] );
 });
 
-test( "should tokenize second (ss) with padding", function() {
-	deepEqual( tokenizer( "59", "ss", cldr ), [{
+QUnit.test( "should tokenize second (ss) with padding", function( assert ) {
+	assert.deepEqual( tokenizer( "59", "ss", cldr ), [{
 		type: "ss",
 		lexeme: "59"
 	}] );
 });
 
-test( "should tokenize milliseconds (S+)", function() {
-	deepEqual( tokenizer( "4", "S", cldr ), [{
+QUnit.test( "should tokenize milliseconds (S+)", function( assert ) {
+	assert.deepEqual( tokenizer( "4", "S", cldr ), [{
 		type: "S",
 		lexeme: "4"
 	}] );
-	deepEqual( tokenizer( "37", "SS", cldr ), [{
+	assert.deepEqual( tokenizer( "37", "SS", cldr ), [{
 		type: "SS",
 		lexeme: "37"
 	}] );
-	deepEqual( tokenizer( "369", "SSS", cldr ), [{
+	assert.deepEqual( tokenizer( "369", "SSS", cldr ), [{
 		type: "SSS",
 		lexeme: "369"
 	}] );
-	deepEqual( tokenizer( "3690", "SSSS", cldr ), [{
+	assert.deepEqual( tokenizer( "3690", "SSSS", cldr ), [{
 		type: "SSSS",
 		lexeme: "3690"
 	}] );
-	deepEqual( tokenizer( "36900", "SSSSS", cldr ), [{
+	assert.deepEqual( tokenizer( "36900", "SSSSS", cldr ), [{
 		type: "SSSSS",
 		lexeme: "36900"
 	}] );
 });
 
-test( "should tokenize milliseconds in a day (A+)", function() {
-	deepEqual( tokenizer( "633074", "A", cldr ), [{
+QUnit.test( "should tokenize milliseconds in a day (A+)", function( assert ) {
+	assert.deepEqual( tokenizer( "633074", "A", cldr ), [{
 		type: "A",
 		lexeme: "633074"
 	}] );
-	deepEqual( tokenizer( "6330737", "AA", cldr ), [{
+	assert.deepEqual( tokenizer( "6330737", "AA", cldr ), [{
 		type: "AA",
 		lexeme: "6330737"
 	}] );
-	deepEqual( tokenizer( "63307369", "AAA", cldr ), [{
+	assert.deepEqual( tokenizer( "63307369", "AAA", cldr ), [{
 		type: "AAA",
 		lexeme: "63307369"
 	}] );
-	deepEqual( tokenizer( "633073690", "AAAA", cldr ), [{
+	assert.deepEqual( tokenizer( "633073690", "AAAA", cldr ), [{
 		type: "AAAA",
 		lexeme: "633073690"
 	}] );
-	deepEqual( tokenizer( "6330736900", "AAAAA", cldr ), [{
+	assert.deepEqual( tokenizer( "6330736900", "AAAAA", cldr ), [{
 		type: "AAAAA",
 		lexeme: "6330736900"
 	}] );

--- a/test/unit/number/format.js
+++ b/test/unit/number/format.js
@@ -23,205 +23,205 @@ ar = new Cldr( "ar" );
 en = new Cldr( "en" );
 es = new Cldr( "es" );
 
-module( "Number Format" );
+QUnit.module( "Number Format" );
 
 /**
  *  Integers
  */
 
-test( "should format integers", function() {
-	equal( format( pi, "#0", en ), "3" );
-	equal( format( pi, "###0", en ), "3" );
+QUnit.test( "should format integers", function( assert ) {
+	assert.equal( format( pi, "#0", en ), "3" );
+	assert.equal( format( pi, "###0", en ), "3" );
 });
 
-test( "should zero-pad minimum integer digits", function() {
-	equal( format( pi, "0", en ), "3" );
-	equal( format( pi, "00", en ), "03" );
-	equal( format( pi, "000", en ), "003" );
+QUnit.test( "should zero-pad minimum integer digits", function( assert ) {
+	assert.equal( format( pi, "0", en ), "3" );
+	assert.equal( format( pi, "00", en ), "03" );
+	assert.equal( format( pi, "000", en ), "003" );
 });
 
-test( "should not limit the maximum number of digits of integers", function() {
-	equal( format( earthDiameter, "0", en ), "12735" );
-	equal( format( earthDiameter, "00", en ), "12735" );
-	equal( format( earthDiameter, "#0", en ), "12735" );
+QUnit.test( "should not limit the maximum number of digits of integers", function( assert ) {
+	assert.equal( format( earthDiameter, "0", en ), "12735" );
+	assert.equal( format( earthDiameter, "00", en ), "12735" );
+	assert.equal( format( earthDiameter, "#0", en ), "12735" );
 });
 
-test( "should format negative integer", function() {
-	equal( format( -earthDiameter, "0", en ), "-12735" );
-	equal( format( -earthDiameter, "0;(0)", en ), "(12735)" );
+QUnit.test( "should format negative integer", function( assert ) {
+	assert.equal( format( -earthDiameter, "0", en ), "-12735" );
+	assert.equal( format( -earthDiameter, "0;(0)", en ), "(12735)" );
 
 	// The number of digits, minimal digits, and other characteristics shall be ignored in the negative subpattern.
-	equal( format( -earthDiameter, "0;(0.0##)", en ), "(12735)" );
+	assert.equal( format( -earthDiameter, "0;(0.0##)", en ), "(12735)" );
 });
 
 /**
  *  Decimals
  */
 
-test( "should format decimals", function() {
-	equal( format( pi, "0.##", en ), "3.14" );
+QUnit.test( "should format decimals", function( assert ) {
+	assert.equal( format( pi, "0.##", en ), "3.14" );
 });
 
-test( "should limit maximum fraction digits", function() {
-	equal( format( pi, "0.##", en ), "3.14" );
-	equal( format( pi, "0.0#", en ), "3.14" );
-	equal( format( pi, "0.####", en ), "3.1416" );
-	equal( format( 0.10004, "0.##", en ), "0.1" );
+QUnit.test( "should limit maximum fraction digits", function( assert ) {
+	assert.equal( format( pi, "0.##", en ), "3.14" );
+	assert.equal( format( pi, "0.0#", en ), "3.14" );
+	assert.equal( format( pi, "0.####", en ), "3.1416" );
+	assert.equal( format( 0.10004, "0.##", en ), "0.1" );
 });
 
-test( "should zero-pad minimum fraction digits", function() {
-	equal( format( earthDiameter, "0.0", en ), "12735.0" );
-	equal( format( deci, "0.00", en ), "0.10" );
+QUnit.test( "should zero-pad minimum fraction digits", function( assert ) {
+	assert.equal( format( earthDiameter, "0.0", en ), "12735.0" );
+	assert.equal( format( deci, "0.00", en ), "0.10" );
 });
 
-test( "should localize decimal separator symbol (.)", function() {
-	equal( format( pi, "0.##", es ), "3,14" );
-	equal( format( pi, "0.##", ar ), "3٫14" );
+QUnit.test( "should localize decimal separator symbol (.)", function( assert ) {
+	assert.equal( format( pi, "0.##", es ), "3,14" );
+	assert.equal( format( pi, "0.##", ar ), "3٫14" );
 });
 
-test( "should allow integer and fraction options override", function() {
-	equal( format( pi, "0.##", en, { minimumIntegerDigits: 2 } ), "03.14" );
-	equal( format( pi, "0.##", en, { maximumFractionDigits: 1 } ), "3.1" );
-	equal( format( 0.1, "0.##", en, { minimumFractionDigits: 2 } ), "0.10" );
-	equal( format( 1.1, "0.##", en, {
+QUnit.test( "should allow integer and fraction options override", function( assert ) {
+	assert.equal( format( pi, "0.##", en, { minimumIntegerDigits: 2 } ), "03.14" );
+	assert.equal( format( pi, "0.##", en, { maximumFractionDigits: 1 } ), "3.1" );
+	assert.equal( format( 0.1, "0.##", en, { minimumFractionDigits: 2 } ), "0.10" );
+	assert.equal( format( 1.1, "0.##", en, {
 		minimumIntegerDigits: 2,
 		minimumFractionDigits: 3
 	}), "01.100" );
 
 	// Use minimumFractionDigits, but no maximumFractionDigits. Sanity check.
-	equal( format( pi, "0.##", en, { minimumFractionDigits: 4 }), "3.1416" );
+	assert.equal( format( pi, "0.##", en, { minimumFractionDigits: 4 }), "3.1416" );
 });
 
-test( "should allow rounding", function() {
-	equal( format( pi, "0.10", en ), "3.10" );
-	equal( format( pi, "0.20", en ), "3.20" );
-	equal( format( pi, "0.5", en ), "3.0" );
-	equal( format( pi, "0.1", en ), "3.1" );
+QUnit.test( "should allow rounding", function( assert ) {
+	assert.equal( format( pi, "0.10", en ), "3.10" );
+	assert.equal( format( pi, "0.20", en ), "3.20" );
+	assert.equal( format( pi, "0.5", en ), "3.0" );
+	assert.equal( format( pi, "0.1", en ), "3.1" );
 });
 
-test( "should allow different rounding options", function() {
-	equal( format( pi, "0.##", en, { round: "ceil" } ), "3.15" );
-	equal( format( pi, "0.##", en, { round: "floor"} ), "3.14" );
-	equal( format( pi, "0.##", en, { round: "round" } ), "3.14" );
-	equal( format( pi, "0.##", en, { round: "truncate"} ), "3.14" );
-	equal( format( pi, "0.####", en, { round: "ceil" } ), "3.1416" );
-	equal( format( pi, "0.####", en, { round: "floor"} ), "3.1415" );
-	equal( format( pi, "0.####", en, { round: "round" } ), "3.1416" );
-	equal( format( pi, "0.####", en, { round: "truncate"} ), "3.1415" );
-	equal( format( -pi, "0.##", en, { round: "ceil" } ), "-3.14" );
-	equal( format( -pi, "0.##", en, { round: "floor"} ), "-3.15" );
-	equal( format( -pi, "0.##", en, { round: "round" } ), "-3.14" );
-	equal( format( -pi, "0.##", en, { round: "truncate"} ), "-3.14" );
-	equal( format( -pi, "0.####", en, { round: "ceil" } ), "-3.1415" );
-	equal( format( -pi, "0.####", en, { round: "floor"} ), "-3.1416" );
-	equal( format( -pi, "0.####", en, { round: "round" } ), "-3.1416" );
-	equal( format( -pi, "0.####", en, { round: "truncate"} ), "-3.1415" );
+QUnit.test( "should allow different rounding options", function( assert ) {
+	assert.equal( format( pi, "0.##", en, { round: "ceil" } ), "3.15" );
+	assert.equal( format( pi, "0.##", en, { round: "floor"} ), "3.14" );
+	assert.equal( format( pi, "0.##", en, { round: "round" } ), "3.14" );
+	assert.equal( format( pi, "0.##", en, { round: "truncate"} ), "3.14" );
+	assert.equal( format( pi, "0.####", en, { round: "ceil" } ), "3.1416" );
+	assert.equal( format( pi, "0.####", en, { round: "floor"} ), "3.1415" );
+	assert.equal( format( pi, "0.####", en, { round: "round" } ), "3.1416" );
+	assert.equal( format( pi, "0.####", en, { round: "truncate"} ), "3.1415" );
+	assert.equal( format( -pi, "0.##", en, { round: "ceil" } ), "-3.14" );
+	assert.equal( format( -pi, "0.##", en, { round: "floor"} ), "-3.15" );
+	assert.equal( format( -pi, "0.##", en, { round: "round" } ), "-3.14" );
+	assert.equal( format( -pi, "0.##", en, { round: "truncate"} ), "-3.14" );
+	assert.equal( format( -pi, "0.####", en, { round: "ceil" } ), "-3.1415" );
+	assert.equal( format( -pi, "0.####", en, { round: "floor"} ), "-3.1416" );
+	assert.equal( format( -pi, "0.####", en, { round: "round" } ), "-3.1416" );
+	assert.equal( format( -pi, "0.####", en, { round: "truncate"} ), "-3.1415" );
 });
 
-test( "should format significant digits", function() {
-	equal( format( 123, "@@@", en ), "123" );
-	equal( format( 12345, "@@@", en ), "12300" );
-	equal( format( 12345, "@@#", en ), "12300" );
-	equal( format( 12345, "@##", en ), "12300" );
-	equal( format( pi, "@@", en ), "3.1" );
-	equal( format( pi, "@@#", en ), "3.14" );
-	equal( format( pi, "@@##", en ), "3.142" );
-	equal( format( pi, "@####", en ), "3.1416" );
-	equal( format( 0.10004, "@@", en ), "0.10" );
-	equal( format( 0.10004, "@##", en ), "0.1" );
-	equal( format( 0.12345, "@@@", en ), "0.123" );
-	equal( format( 1.23004, "@@##", en ), "1.23" );
+QUnit.test( "should format significant digits", function( assert ) {
+	assert.equal( format( 123, "@@@", en ), "123" );
+	assert.equal( format( 12345, "@@@", en ), "12300" );
+	assert.equal( format( 12345, "@@#", en ), "12300" );
+	assert.equal( format( 12345, "@##", en ), "12300" );
+	assert.equal( format( pi, "@@", en ), "3.1" );
+	assert.equal( format( pi, "@@#", en ), "3.14" );
+	assert.equal( format( pi, "@@##", en ), "3.142" );
+	assert.equal( format( pi, "@####", en ), "3.1416" );
+	assert.equal( format( 0.10004, "@@", en ), "0.10" );
+	assert.equal( format( 0.10004, "@##", en ), "0.1" );
+	assert.equal( format( 0.12345, "@@@", en ), "0.123" );
+	assert.equal( format( 1.23004, "@@##", en ), "1.23" );
 });
 
-test( "should format negative decimal", function() {
-	equal( format( -pi, "0.##", en ), "-3.14" );
-	equal( format( -pi, "0.##;(0.##)", en ), "(3.14)" );
-	equal( format( -pi, "@@#", en ), "-3.14" );
-	equal( format( -pi, "@@#;(@@#)", en ), "(3.14)" );
+QUnit.test( "should format negative decimal", function( assert ) {
+	assert.equal( format( -pi, "0.##", en ), "-3.14" );
+	assert.equal( format( -pi, "0.##;(0.##)", en ), "(3.14)" );
+	assert.equal( format( -pi, "@@#", en ), "-3.14" );
+	assert.equal( format( -pi, "@@#;(@@#)", en ), "(3.14)" );
 
 	// The number of digits, minimal digits, and other characteristics shall be ignored in the negative subpattern.
-	equal( format( -pi, "0.##;(0)", en ), "(3.14)" );
-	equal( format( -pi, "@@#;(0)", en ), "(3.14)" );
+	assert.equal( format( -pi, "0.##;(0)", en ), "(3.14)" );
+	assert.equal( format( -pi, "@@#;(0)", en ), "(3.14)" );
 });
 
 /**
  *  Grouping separators
  */
 
-test( "should format grouping separators", function() {
-	equal( format( earthDiameter, "#,##0.#", en ), "12,735" );
-	equal( format( earthDiameter, "#,#,#0.#", en ), "1,2,7,35" );
-	equal( format( 123456789, "#,##,###,###0", en ), "12,345,6789" );
-	equal( format( 123456789, "###,###,###0", en ), "12,345,6789" );
-	equal( format( 123456789, "##,#,###,###0", en ), "12,345,6789" );
+QUnit.test( "should format grouping separators", function( assert ) {
+	assert.equal( format( earthDiameter, "#,##0.#", en ), "12,735" );
+	assert.equal( format( earthDiameter, "#,#,#0.#", en ), "1,2,7,35" );
+	assert.equal( format( 123456789, "#,##,###,###0", en ), "12,345,6789" );
+	assert.equal( format( 123456789, "###,###,###0", en ), "12,345,6789" );
+	assert.equal( format( 123456789, "##,#,###,###0", en ), "12,345,6789" );
 });
 
 /**
  *  Percent
  */
 
-test( "should format percent", function() {
-	equal( format( 0.01, "0%", en ), "1%" );
-	equal( format( 0.01, "00%", en ), "01%" );
-	equal( format( 0.1, "0%", en ), "10%" );
-	equal( format( 0.5, "#0%", en ), "50%" );
-	equal( format( 1, "0%", en ), "100%" );
-	equal( format( 0.005, "##0.#%", en ), "0.5%" );
-	equal( format( 0.005, "##0.#%", en ), "0.5%" );
+QUnit.test( "should format percent", function( assert ) {
+	assert.equal( format( 0.01, "0%", en ), "1%" );
+	assert.equal( format( 0.01, "00%", en ), "01%" );
+	assert.equal( format( 0.1, "0%", en ), "10%" );
+	assert.equal( format( 0.5, "#0%", en ), "50%" );
+	assert.equal( format( 1, "0%", en ), "100%" );
+	assert.equal( format( 0.005, "##0.#%", en ), "0.5%" );
+	assert.equal( format( 0.005, "##0.#%", en ), "0.5%" );
 });
 
-test( "should localize percent symbol (%)", function() {
-	equal( format( 0.5, "#0%", ar ), "50٪" );
+QUnit.test( "should localize percent symbol (%)", function( assert ) {
+	assert.equal( format( 0.5, "#0%", ar ), "50٪" );
 });
 
-test( "should format negative percentage", function() {
-	equal( format( -0.1, "0%", en ), "-10%" );
-	equal( format( -0.1, "0%;(0%)", en ), "(10%)" );
-	equal( format( -0.1, "0%;(0)%", en ), "(10)%" );
+QUnit.test( "should format negative percentage", function( assert ) {
+	assert.equal( format( -0.1, "0%", en ), "-10%" );
+	assert.equal( format( -0.1, "0%;(0%)", en ), "(10%)" );
+	assert.equal( format( -0.1, "0%;(0)%", en ), "(10)%" );
 });
 
 /**
  *  Per mille
  */
 
-test( "should format per mille", function() {
-	equal( format( 0.001, "0\u2030", en ), "1\u2030" );
-	equal( format( 0.001, "00\u2030", en ), "01\u2030" );
-	equal( format( 0.01, "0\u2030", en ), "10\u2030" );
-	equal( format( 0.1, "0\u2030", en ), "100\u2030" );
-	equal( format( 0.5, "#0\u2030", en ), "500\u2030" );
-	equal( format( 1, "0\u2030", en ), "1000\u2030" );
-	equal( format( 0.0005, "##0.#\u2030", en ), "0.5\u2030" );
-	equal( format( 0.0005, "##0.#\u2030", en ), "0.5\u2030" );
-	equal( format( 0.5, "#0‰", en ), "500\u2030" );
-	equal( format( 0.5, "#0‰", en ), "500‰" );
+QUnit.test( "should format per mille", function( assert ) {
+	assert.equal( format( 0.001, "0\u2030", en ), "1\u2030" );
+	assert.equal( format( 0.001, "00\u2030", en ), "01\u2030" );
+	assert.equal( format( 0.01, "0\u2030", en ), "10\u2030" );
+	assert.equal( format( 0.1, "0\u2030", en ), "100\u2030" );
+	assert.equal( format( 0.5, "#0\u2030", en ), "500\u2030" );
+	assert.equal( format( 1, "0\u2030", en ), "1000\u2030" );
+	assert.equal( format( 0.0005, "##0.#\u2030", en ), "0.5\u2030" );
+	assert.equal( format( 0.0005, "##0.#\u2030", en ), "0.5\u2030" );
+	assert.equal( format( 0.5, "#0‰", en ), "500\u2030" );
+	assert.equal( format( 0.5, "#0‰", en ), "500‰" );
 });
 
-test( "should localize per mille symbol (\u2030)", function() {
-	equal( format( 0.5, "#0\u2030", ar ), "500؉" );
+QUnit.test( "should localize per mille symbol (\u2030)", function( assert ) {
+	assert.equal( format( 0.5, "#0\u2030", ar ), "500؉" );
 });
 
-test( "should format negative mille", function() {
-	equal( format( -0.001, "0\u2030", en ), "-1\u2030" );
-	equal( format( -0.001, "0\u2030;(0\u2030)", en ), "(1\u2030)" );
-	equal( format( -0.001, "0\u2030;(0)\u2030", en ), "(1)\u2030" );
+QUnit.test( "should format negative mille", function( assert ) {
+	assert.equal( format( -0.001, "0\u2030", en ), "-1\u2030" );
+	assert.equal( format( -0.001, "0\u2030;(0\u2030)", en ), "(1\u2030)" );
+	assert.equal( format( -0.001, "0\u2030;(0)\u2030", en ), "(1)\u2030" );
 });
 
 /**
  *  Infinity
  */
 
-test( "should format infinite numbers", function() {
-	equal( format( Math.pow(2, 2000), "0", en ), "∞" );
-	equal( format( Math.pow(-2, 2001), "0", en ), "-∞" );
+QUnit.test( "should format infinite numbers", function( assert ) {
+	assert.equal( format( Math.pow(2, 2000), "0", en ), "∞" );
+	assert.equal( format( Math.pow(-2, 2001), "0", en ), "-∞" );
 });
 
 /**
  *  NaN
  */
 
-test( "should format infinite numbers", function() {
-	equal( format( NaN, "0", en ), "NaN" );
+QUnit.test( "should format infinite numbers", function( assert ) {
+	assert.equal( format( NaN, "0", en ), "NaN" );
 });
 
 });

--- a/test/unit/number/format/grouping-separator.js
+++ b/test/unit/number/format/grouping-separator.js
@@ -2,24 +2,24 @@ define([
 	"globalize/number/format/grouping-separator"
 ], function( groupingSeparator ) {
 
-module( "Number Format Grouping Separator" );
+QUnit.module( "Number Format Grouping Separator" );
 
-test( "should format primary grouping separator", function() {
-	equal( groupingSeparator( 1, 2 ), "1" );
-	equal( groupingSeparator( 11, 2 ), "11" );
-	equal( groupingSeparator( 111, 2 ), "1,11" );
-	equal( groupingSeparator( 1111, 2 ), "11,11" );
-	equal( groupingSeparator( 11111, 2 ), "1,11,11" );
-	equal( groupingSeparator( 1111111, 3 ), "1,111,111" );
-	equal( groupingSeparator( 1111111.1111, 3 ), "1,111,111.1111" );
+QUnit.test( "should format primary grouping separator", function( assert ) {
+	assert.equal( groupingSeparator( 1, 2 ), "1" );
+	assert.equal( groupingSeparator( 11, 2 ), "11" );
+	assert.equal( groupingSeparator( 111, 2 ), "1,11" );
+	assert.equal( groupingSeparator( 1111, 2 ), "11,11" );
+	assert.equal( groupingSeparator( 11111, 2 ), "1,11,11" );
+	assert.equal( groupingSeparator( 1111111, 3 ), "1,111,111" );
+	assert.equal( groupingSeparator( 1111111.1111, 3 ), "1,111,111.1111" );
 });
 
-test( "should format primary and second grouping separator", function() {
-	equal( groupingSeparator( 111111, 3, 2 ), "1,11,111" );
-	equal( groupingSeparator( 1111111, 3, 2 ), "11,11,111" );
-	equal( groupingSeparator( 11111111, 3, 2 ), "1,11,11,111" );
-	equal( groupingSeparator( 11111111, 2, 1 ), "1,1,1,1,1,1,11" );
-	equal( groupingSeparator( 11111111.1111, 2, 1 ), "1,1,1,1,1,1,11.1111" );
+QUnit.test( "should format primary and second grouping separator", function( assert ) {
+	assert.equal( groupingSeparator( 111111, 3, 2 ), "1,11,111" );
+	assert.equal( groupingSeparator( 1111111, 3, 2 ), "11,11,111" );
+	assert.equal( groupingSeparator( 11111111, 3, 2 ), "1,11,11,111" );
+	assert.equal( groupingSeparator( 11111111, 2, 1 ), "1,1,1,1,1,1,11" );
+	assert.equal( groupingSeparator( 11111111.1111, 2, 1 ), "1,1,1,1,1,1,11.1111" );
 });
 
 });

--- a/test/unit/number/format/integer-fraction-digits.js
+++ b/test/unit/number/format/integer-fraction-digits.js
@@ -14,60 +14,60 @@ var ceil = round( "ceil" ),
 
 round = round( "round" ),
 
-module( "Number Integer and Fraction Format" );
+QUnit.module( "Number Integer and Fraction Format" );
 
 /**
  *  Integers
  */
 
-test( "should zero-pad minimum integer digits", function() {
-	equal( formatIntegerFractionDigits( pi, 2, null, null, round, null ), "03" );
+QUnit.test( "should zero-pad minimum integer digits", function( assert ) {
+	assert.equal( formatIntegerFractionDigits( pi, 2, null, null, round, null ), "03" );
 });
 
-test( "should not limit the maximum number of digits of integers", function() {
-	equal( formatIntegerFractionDigits( earthDiameter, 1, null, null, round, null ), "12735" );
+QUnit.test( "should not limit the maximum number of digits of integers", function( assert ) {
+	assert.equal( formatIntegerFractionDigits( earthDiameter, 1, null, null, round, null ), "12735" );
 });
 
 /**
  *  Decimals
  */
 
-test( "should limit maximum fraction digits", function() {
-	equal( formatIntegerFractionDigits( pi, 1, 0, 2, round, null ), "3.14" );
-	equal( formatIntegerFractionDigits( pi, 1, 4, 4, round, null ), "3.1416" );
+QUnit.test( "should limit maximum fraction digits", function( assert ) {
+	assert.equal( formatIntegerFractionDigits( pi, 1, 0, 2, round, null ), "3.14" );
+	assert.equal( formatIntegerFractionDigits( pi, 1, 4, 4, round, null ), "3.1416" );
 });
 
-test( "should zero-pad minimum fraction digits", function() {
-	equal( formatIntegerFractionDigits( deci, 1, 2, 2, round, null ), "0.10" );
+QUnit.test( "should zero-pad minimum fraction digits", function( assert ) {
+	assert.equal( formatIntegerFractionDigits( deci, 1, 2, 2, round, null ), "0.10" );
 });
 
-test( "should allow rounding", function() {
-	equal( formatIntegerFractionDigits( pi, 1, 2, 2, round, 0.10 ), "3.10" );
+QUnit.test( "should allow rounding", function( assert ) {
+	assert.equal( formatIntegerFractionDigits( pi, 1, 2, 2, round, 0.10 ), "3.10" );
 });
 
-test( "should allow different rounding options", function() {
-	equal( formatIntegerFractionDigits( pi, 1, 0, 2, ceil, null ), "3.15" );
-	equal( formatIntegerFractionDigits( pi, 1, 0, 2, floor, null ), "3.14" );
-	equal( formatIntegerFractionDigits( pi, 1, 0, 2, round, null ), "3.14" );
-	equal( formatIntegerFractionDigits( pi, 1, 0, 2, truncate, null ), "3.14" );
-	equal( formatIntegerFractionDigits( pi, 1, 0, 4, ceil, null ), "3.1416" );
-	equal( formatIntegerFractionDigits( pi, 1, 0, 4, floor, null), "3.1415" );
-	equal( formatIntegerFractionDigits( pi, 1, 0, 4, round, null ), "3.1416" );
-	equal( formatIntegerFractionDigits( pi, 1, 0, 4, truncate, null ), "3.1415" );
-	equal( formatIntegerFractionDigits( -pi, 1, 0, 2, ceil, null ), "-3.14" );
-	equal( formatIntegerFractionDigits( -pi, 1, 0, 2, floor, null ), "-3.15" );
-	equal( formatIntegerFractionDigits( -pi, 1, 0, 2, round, null ), "-3.14" );
-	equal( formatIntegerFractionDigits( -pi, 1, 0, 2, truncate, null ), "-3.14" );
-	equal( formatIntegerFractionDigits( -pi, 1, 0, 4, ceil, null ), "-3.1415" );
-	equal( formatIntegerFractionDigits( -pi, 1, 0, 4, floor, null ), "-3.1416" );
-	equal( formatIntegerFractionDigits( -pi, 1, 0, 4, round, null ), "-3.1416" );
-	equal( formatIntegerFractionDigits( -pi, 1, 0, 4, truncate, null ), "-3.1415" );
+QUnit.test( "should allow different rounding options", function( assert ) {
+	assert.equal( formatIntegerFractionDigits( pi, 1, 0, 2, ceil, null ), "3.15" );
+	assert.equal( formatIntegerFractionDigits( pi, 1, 0, 2, floor, null ), "3.14" );
+	assert.equal( formatIntegerFractionDigits( pi, 1, 0, 2, round, null ), "3.14" );
+	assert.equal( formatIntegerFractionDigits( pi, 1, 0, 2, truncate, null ), "3.14" );
+	assert.equal( formatIntegerFractionDigits( pi, 1, 0, 4, ceil, null ), "3.1416" );
+	assert.equal( formatIntegerFractionDigits( pi, 1, 0, 4, floor, null), "3.1415" );
+	assert.equal( formatIntegerFractionDigits( pi, 1, 0, 4, round, null ), "3.1416" );
+	assert.equal( formatIntegerFractionDigits( pi, 1, 0, 4, truncate, null ), "3.1415" );
+	assert.equal( formatIntegerFractionDigits( -pi, 1, 0, 2, ceil, null ), "-3.14" );
+	assert.equal( formatIntegerFractionDigits( -pi, 1, 0, 2, floor, null ), "-3.15" );
+	assert.equal( formatIntegerFractionDigits( -pi, 1, 0, 2, round, null ), "-3.14" );
+	assert.equal( formatIntegerFractionDigits( -pi, 1, 0, 2, truncate, null ), "-3.14" );
+	assert.equal( formatIntegerFractionDigits( -pi, 1, 0, 4, ceil, null ), "-3.1415" );
+	assert.equal( formatIntegerFractionDigits( -pi, 1, 0, 4, floor, null ), "-3.1416" );
+	assert.equal( formatIntegerFractionDigits( -pi, 1, 0, 4, round, null ), "-3.1416" );
+	assert.equal( formatIntegerFractionDigits( -pi, 1, 0, 4, truncate, null ), "-3.1415" );
 });
 
 // Fix #227
-test( "should ignore decimal error", function() {
-	equal( formatIntegerFractionDigits( 12341234.233, 1, 1, 3, round, null ), "12341234.233" );
-	equal( formatIntegerFractionDigits( 1234 * 0.0001, 1, 1, 4, round, null ), "0.1234" );
+QUnit.test( "should ignore decimal error", function( assert ) {
+	assert.equal( formatIntegerFractionDigits( 12341234.233, 1, 1, 3, round, null ), "12341234.233" );
+	assert.equal( formatIntegerFractionDigits( 1234 * 0.0001, 1, 1, 4, round, null ), "0.1234" );
 });
 
 });

--- a/test/unit/number/format/significant-digits.js
+++ b/test/unit/number/format/significant-digits.js
@@ -1,7 +1,7 @@
 define([
 	"globalize/number/format/significant-digits",
 	"globalize/util/number/round"
-], function( formatSignificantDigits, round) {
+], function( formatSignificantDigits, round ) {
 
 var ceil = round( "ceil" ),
 	deci = 0.1,
@@ -11,31 +11,31 @@ var ceil = round( "ceil" ),
 
 round = round( "round" ),
 
-module( "Number Significant Format" );
+QUnit.module( "Number Significant Format" );
 
-test( "should zero-pad minimum significant figures", function() {
-	equal( formatSignificantDigits( deci, 3, 3, round ), "0.100" );
+QUnit.test( "should zero-pad minimum significant figures", function( assert ) {
+	assert.equal( formatSignificantDigits( deci, 3, 3, round ), "0.100" );
 });
 
-test( "should limit maximum significant figures", function() {
-	equal( formatSignificantDigits( 123, 3, 3, round ), "123" );
-	equal( formatSignificantDigits( 12345, 3, 3, round ), "12300" );
-	equal( formatSignificantDigits( pi, 2, 2, round ), "3.1" );
-	equal( formatSignificantDigits( pi, 2, 3, round ), "3.14" );
-	equal( formatSignificantDigits( pi, 2, 4, round ), "3.142" );
-	equal( formatSignificantDigits( pi, 1, 5, round ), "3.1416" );
-	equal( formatSignificantDigits( 0.10004, 2, 2, round ), "0.10" );
-	equal( formatSignificantDigits( 0.12345, 3, 3, round ), "0.123" );
-	equal( formatSignificantDigits( 0.012345, 3, 3, round ), "0.0123" );
+QUnit.test( "should limit maximum significant figures", function( assert ) {
+	assert.equal( formatSignificantDigits( 123, 3, 3, round ), "123" );
+	assert.equal( formatSignificantDigits( 12345, 3, 3, round ), "12300" );
+	assert.equal( formatSignificantDigits( pi, 2, 2, round ), "3.1" );
+	assert.equal( formatSignificantDigits( pi, 2, 3, round ), "3.14" );
+	assert.equal( formatSignificantDigits( pi, 2, 4, round ), "3.142" );
+	assert.equal( formatSignificantDigits( pi, 1, 5, round ), "3.1416" );
+	assert.equal( formatSignificantDigits( 0.10004, 2, 2, round ), "0.10" );
+	assert.equal( formatSignificantDigits( 0.12345, 3, 3, round ), "0.123" );
+	assert.equal( formatSignificantDigits( 0.012345, 3, 3, round ), "0.0123" );
 });
 
-test( "should allow different round options", function() {
-	equal( formatSignificantDigits( 0.12345, 3, 3, ceil ), "0.124" );
-	equal( formatSignificantDigits( 0.12345, 3, 3, floor ), "0.123" );
-	equal( formatSignificantDigits( 0.12345, 3, 3, truncate ), "0.123" );
-	equal( formatSignificantDigits( -0.12345, 3, 3, ceil ), "-0.123" );
-	equal( formatSignificantDigits( -0.12345, 3, 3, floor ), "-0.124" );
-	equal( formatSignificantDigits( -0.12345, 3, 3, truncate ), "-0.123" );
+QUnit.test( "should allow different round options", function( assert ) {
+	assert.equal( formatSignificantDigits( 0.12345, 3, 3, ceil ), "0.124" );
+	assert.equal( formatSignificantDigits( 0.12345, 3, 3, floor ), "0.123" );
+	assert.equal( formatSignificantDigits( 0.12345, 3, 3, truncate ), "0.123" );
+	assert.equal( formatSignificantDigits( -0.12345, 3, 3, ceil ), "-0.123" );
+	assert.equal( formatSignificantDigits( -0.12345, 3, 3, floor ), "-0.124" );
+	assert.equal( formatSignificantDigits( -0.12345, 3, 3, truncate ), "-0.123" );
 });
 
 });

--- a/test/unit/number/parse.js
+++ b/test/unit/number/parse.js
@@ -24,125 +24,125 @@ en = new Cldr( "en" );
 es = new Cldr( "es" );
 sv = new Cldr( "sv" );
 
-module( "Number Parse" );
+QUnit.module( "Number Parse" );
 
 /**
  *  Integers
  */
 
-test( "should parse integers", function() {
-	equal( parse( "3", "0", en ), 3 );
+QUnit.test( "should parse integers", function( assert ) {
+	assert.equal( parse( "3", "0", en ), 3 );
 });
 
-test( "should parse zero-padded integers", function() {
-	equal( parse( "003", "000", en ), 3 );
+QUnit.test( "should parse zero-padded integers", function( assert ) {
+	assert.equal( parse( "003", "000", en ), 3 );
 });
 
-test( "should parse grouping separators", function() {
-	equal( parse( "12,735", "#,##0.#", en ), 12735 );
-	equal( parse( "1,2,7,35", "#,#,#0.#", en ), 12735 );
-	equal( parse( "12.735", "#,##0", es ), 12735 );
+QUnit.test( "should parse grouping separators", function( assert ) {
+	assert.equal( parse( "12,735", "#,##0.#", en ), 12735 );
+	assert.equal( parse( "1,2,7,35", "#,#,#0.#", en ), 12735 );
+	assert.equal( parse( "12.735", "#,##0", es ), 12735 );
 });
 
-test( "should parse negative integers", function() {
-	equal( parse( "-3", "0", en ), -3 );
-	equal( parse( "(3)", "0;(0)", en ), -3 );
+QUnit.test( "should parse negative integers", function( assert ) {
+	assert.equal( parse( "-3", "0", en ), -3 );
+	assert.equal( parse( "(3)", "0;(0)", en ), -3 );
 });
 
 /**
  *  Decimals
  */
 
-test( "should parse decimals", function() {
-	equal( parse( "3.14", "0.##", en ), 3.14 );
-	equal( parse( "3,14", "0.##", es ), 3.14 );
-	equal( parse( "3٫14", "0.##", ar ), 3.14 );
-	equal( parse( "3.00", "0.##", en ), 3 );
+QUnit.test( "should parse decimals", function( assert ) {
+	assert.equal( parse( "3.14", "0.##", en ), 3.14 );
+	assert.equal( parse( "3,14", "0.##", es ), 3.14 );
+	assert.equal( parse( "3٫14", "0.##", ar ), 3.14 );
+	assert.equal( parse( "3.00", "0.##", en ), 3 );
 });
 
-test( "should parse zero-padded decimals", function() {
-	equal( parse( "12735.0", "0.0", en ), 12735 );
-	equal( parse( "0.10", "0.00", en ), 0.1 );
+QUnit.test( "should parse zero-padded decimals", function( assert ) {
+	assert.equal( parse( "12735.0", "0.0", en ), 12735 );
+	assert.equal( parse( "0.10", "0.00", en ), 0.1 );
 });
 
-test( "should parse negative decimal", function() {
-	equal( parse( "-3.14", "0.##", en ), -3.14 );
-	equal( parse( "(3.14)", "0.##;(0.##)", en ), -3.14 );
+QUnit.test( "should parse negative decimal", function( assert ) {
+	assert.equal( parse( "-3.14", "0.##", en ), -3.14 );
+	assert.equal( parse( "(3.14)", "0.##;(0.##)", en ), -3.14 );
 });
 
 /**
  *  Percent
  */
 
-test( "should parse percent", function() {
-	equal( parse( "1%", "0%", en ), 0.01 );
-	equal( parse( "01%", "00%", en ), 0.01 );
-	equal( parse( "10%", "0%", en ), 0.1 );
-	equal( parse( "50%", "#0%", en ), 0.5 );
-	equal( parse( "100%", "0%", en ), 1 );
-	equal( parse( "0.5%", "##0.#%", en ), 0.005 );
-	equal( parse( "0.5%", "##0.#%", en ), 0.005 );
+QUnit.test( "should parse percent", function( assert ) {
+	assert.equal( parse( "1%", "0%", en ), 0.01 );
+	assert.equal( parse( "01%", "00%", en ), 0.01 );
+	assert.equal( parse( "10%", "0%", en ), 0.1 );
+	assert.equal( parse( "50%", "#0%", en ), 0.5 );
+	assert.equal( parse( "100%", "0%", en ), 1 );
+	assert.equal( parse( "0.5%", "##0.#%", en ), 0.005 );
+	assert.equal( parse( "0.5%", "##0.#%", en ), 0.005 );
 });
 
-test( "should localize percent symbol (%)", function() {
-	equal( parse( "50٪", "#0%", ar ), 0.5 );
+QUnit.test( "should localize percent symbol (%)", function( assert ) {
+	assert.equal( parse( "50٪", "#0%", ar ), 0.5 );
 });
 
-test( "should parse negative percentage", function() {
-	equal( parse( "-10%", "0%", en ), -0.1 );
-	equal( parse( "(10%)", "0%;(0%)", en ), -0.1 );
-	equal( parse( "(10)%", "0%;(0)%", en ), -0.1 );
+QUnit.test( "should parse negative percentage", function( assert ) {
+	assert.equal( parse( "-10%", "0%", en ), -0.1 );
+	assert.equal( parse( "(10%)", "0%;(0%)", en ), -0.1 );
+	assert.equal( parse( "(10)%", "0%;(0)%", en ), -0.1 );
 });
 
 /**
  *  Per mille
  */
 
-test( "should parse per mille", function() {
-	equal( parse( "1\u2030", "0\u2030", en ), 0.001 );
-	equal( parse( "01\u2030", "00\u2030", en ), 0.001 );
-	equal( parse( "10\u2030", "0\u2030", en ), 0.01 );
-	equal( parse( "100\u2030", "0\u2030", en ), 0.1 );
-	equal( parse( "500\u2030", "#0\u2030", en ), 0.5 );
-	equal( parse( "1000\u2030", "0\u2030", en ), 1 );
-	equal( parse( "0.5\u2030", "##0.#\u2030", en ), 0.0005 );
-	equal( parse( "0.5\u2030", "##0.#\u2030", en ), 0.0005 );
-	equal( parse( "500\u2030", "#0‰", en ), 0.5 );
-	equal( parse( "500‰", "#0‰", en ), 0.5 );
-	equal( parse( "500؉", "#0\u2030", ar ), 0.5 );
+QUnit.test( "should parse per mille", function( assert ) {
+	assert.equal( parse( "1\u2030", "0\u2030", en ), 0.001 );
+	assert.equal( parse( "01\u2030", "00\u2030", en ), 0.001 );
+	assert.equal( parse( "10\u2030", "0\u2030", en ), 0.01 );
+	assert.equal( parse( "100\u2030", "0\u2030", en ), 0.1 );
+	assert.equal( parse( "500\u2030", "#0\u2030", en ), 0.5 );
+	assert.equal( parse( "1000\u2030", "0\u2030", en ), 1 );
+	assert.equal( parse( "0.5\u2030", "##0.#\u2030", en ), 0.0005 );
+	assert.equal( parse( "0.5\u2030", "##0.#\u2030", en ), 0.0005 );
+	assert.equal( parse( "500\u2030", "#0‰", en ), 0.5 );
+	assert.equal( parse( "500‰", "#0‰", en ), 0.5 );
+	assert.equal( parse( "500؉", "#0\u2030", ar ), 0.5 );
 });
 
-test( "should parse negative mille", function() {
-	equal( parse( "-1\u2030", "0\u2030", en ), -0.001 );
-	equal( parse( "(1\u2030)", "0\u2030;(0\u2030)", en ), -0.001 );
-	equal( parse( "(1)\u2030", "0\u2030;(0)\u2030", en ), -0.001 );
+QUnit.test( "should parse negative mille", function( assert ) {
+	assert.equal( parse( "-1\u2030", "0\u2030", en ), -0.001 );
+	assert.equal( parse( "(1\u2030)", "0\u2030;(0\u2030)", en ), -0.001 );
+	assert.equal( parse( "(1)\u2030", "0\u2030;(0)\u2030", en ), -0.001 );
 });
 
 /**
  *  Scientific notation
  */
-test( "should parse scientific notation numbers", function() {
-	equal( parse( "3E-3", "0", en ), 0.003 );
-	equal( parse( "3×10^-3", "0", sv ), 0.003 );
+QUnit.test( "should parse scientific notation numbers", function( assert ) {
+	assert.equal( parse( "3E-3", "0", en ), 0.003 );
+	assert.equal( parse( "3×10^-3", "0", sv ), 0.003 );
 });
 
 /**
  *  Infinite number
  */
-test( "should parse infinite numbers", function() {
-	equal( parse( "∞", "0", en ), Infinity );
-	equal( parse( "-∞", "0", en ), -Infinity );
-	equal( parse( "(∞)", "0;(0)", en ), -Infinity );
-	equal( parse( "གྲངས་མེད", "0", dz ), Infinity );
+QUnit.test( "should parse infinite numbers", function( assert ) {
+	assert.equal( parse( "∞", "0", en ), Infinity );
+	assert.equal( parse( "-∞", "0", en ), -Infinity );
+	assert.equal( parse( "(∞)", "0;(0)", en ), -Infinity );
+	assert.equal( parse( "གྲངས་མེད", "0", dz ), Infinity );
 });
 
 /**
  *  NaN
  */
 
-test( "should parse invalid numbers as NaN", function() {
-	deepEqual( parse( "invalid", "0", en ), NaN );
-	deepEqual( parse( "NaN", "0", en ), NaN );
+QUnit.test( "should parse invalid numbers as NaN", function( assert ) {
+	assert.deepEqual( parse( "invalid", "0", en ), NaN );
+	assert.deepEqual( parse( "NaN", "0", en ), NaN );
 });
 
 


### PR DESCRIPTION
As I did in jquery/jquery#1586, I've changed QUnit globals as they are not going to be exposed on further versions of QUnit.
