### PR TITLE
Date: Parse date within month's boundaries when needed

### DIFF
--- a/src/date/parse.js
+++ b/src/date/parse.js
@@ -2,8 +2,10 @@ define([
 	"./pattern-re",
 	"./start-of",
 	"./tokenizer",
-	"../util/array/every"
-], function( datePatternRe, dateStartOf, dateTokenizer, arrayEvery ) {
+	"../util/array/every",
+	"../util/date/set-date",
+	"../util/date/set-month"
+], function( datePatternRe, dateStartOf, dateTokenizer, arrayEvery, dateSetDate, dateSetMonth ) {
 
 function outOfRange( value, low, high ) {
 	return value < low || value > high;
@@ -96,7 +98,7 @@ return function( value, pattern, cldr ) {
 				if( outOfRange( value, 1, 12 ) ) {
 					return false;
 				}
-				date.setMonth( value - 1 );
+				dateSetMonth( date, value - 1 );
 				truncateAt.push( MONTH );
 				break;
 
@@ -111,7 +113,7 @@ return function( value, pattern, cldr ) {
 				if( outOfRange( value, 1, 31 ) ) {
 					return false;
 				}
-				date.setDate( value );
+				dateSetDate( date, value );
 				truncateAt.push( DAY );
 				break;
 

--- a/src/util/date/set-date.js
+++ b/src/util/date/set-date.js
@@ -1,0 +1,16 @@
+define(function() {
+
+/**
+ * Differently from native date.setDate(), this function returns a date whose
+ * day remains inside the month boundaries. For example:
+ *
+ * setDate( FebDate, 31 ): a "Feb 28" date.
+ * setDate( SepDate, 31 ): a "Sep 30" date.
+ */
+return function( date, day ) {
+	var lastDay = new Date( date.getFullYear(), date.getMonth() + 1 , 0 ).getDate();
+	
+	date.setDate( day < 1 ? 1 : day < lastDay ? day : lastDay );
+};
+
+});

--- a/src/util/date/set-month.js
+++ b/src/util/date/set-month.js
@@ -1,0 +1,20 @@
+define([
+	"./set-date"
+], function( dateSetDate ) {
+
+/**
+ * Differently from native date.setMonth(), this function adjusts date if
+ * needed, so final month is always the one set.
+ *
+ * setMonth( Jan31Date, 1 ): a "Feb 28" date.
+ * setDate( Jan31Date, 8 ): a "Sep 30" date.
+ */
+return function( date, month ) {
+	var originalDate = date.getDate();
+	
+	date.setDate( 1 );
+	date.setMonth( month );
+	dateSetDate( date, originalDate );
+};
+
+});


### PR DESCRIPTION
Fix #269 

Date parsing has a component based on today's context. So, it properly parses stuff like `"Jan 1st"` into the Jan 1st of the current year; or `"12:00pm"` into 12:00pm of today.

It happens that if today is "May 31" and we want to parse "Sep 15, 2010", the parsing algorithm first creates a date instance of today/now. Then, as a next step, it sets this date to "Sep". Although, "Sep 31" becomes "Oct 1" according to native date.setMonth(). Then, as a next step, it sets the day and year. The final result becomes erroneously a "Oct 15 2010" date instance.

You may be wondering why don't we parse the given string and keep each component in a separate variable, then assemble a date instance using new Date( each component ). Yes, in this case, it's the easiest thing to do. Although, it would make other date patterns harder to parse, eg. `D` (day of year), in which case we do make use of the native date.setDate() feature that correctly adjusts month and date accordingly when a number is bigger than a month's boundaries.

Anyway, considering the above, this fix that takes special care when setting months so the scenario is handled.
