### PR TITLE
Use curl instead of wget

### DIFF
--- a/examples/amd-bower/README.md
+++ b/examples/amd-bower/README.md
@@ -55,7 +55,7 @@ ZIP](http://www.unicode.org/Public/cldr/latest/json.zip) and unzip it into
 `cldr/`. For more information read [Getting Started](../../README.md#cldr).
 
 ```
-wget http://www.unicode.org/Public/cldr/latest/json.zip
+curl -LOk http://www.unicode.org/Public/cldr/latest/json.zip
 unzip json.zip -d cldr
 ```
 

--- a/examples/node-npm/README.md
+++ b/examples/node-npm/README.md
@@ -50,7 +50,7 @@ ZIP](http://www.unicode.org/Public/cldr/latest/json.zip) and unzip it into
 `cldr/`. For more information read [Getting Started](../../README.md#cldr).
 
 ```
-wget http://www.unicode.org/Public/cldr/latest/json.zip
+curl -LOk http://www.unicode.org/Public/cldr/latest/json.zip
 unzip json.zip -d cldr
 ```
 


### PR DESCRIPTION
Curl builds and runs on lots of more platforms than wget. For example: OS/400, TPF and other more "exotic" platforms that aren't straight-forward unix clones.

Curl supports more protocols: FTP, FTPS, HTTP, HTTPS, SCP, SFTP, TFTP, TELNET, DICT, LDAP, LDAPS, FILE, POP3, IMAP, SMTP, RTMP and RTSP. Wget only supports HTTP, HTTPS and FTP.

Also has other advantages over the wget: http://daniel.haxx.se/docs/curl-vs-wget.html
