### PR TITLE
Remove deprecated JSHint options

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -7,8 +7,6 @@
 	"noarg": true,
 	"onevar": false,
 	"quotmark": "double",
-	"smarttabs": true,
-	"trailing": true,
 	"undef": true,
 	"unused": true,
 


### PR DESCRIPTION
Since JSHint v2.5 the options `smarttabs` & `trailing` are deprecated.
