### PR TITLE
Fix zh-Hant - PM "afternoon" handled correctly

### DIFF
--- a/src/date/parse.js
+++ b/src/date/parse.js
@@ -260,7 +260,7 @@ return function( value, tokens, properties ) {
 		date.setDate( daysOfYear );
 	}
 
-	if ( hour12 && amPm === "pm" ) {
+	if ( hour12 && (amPm === "pm" || amPm === "afternoon") ) {
 		date.setHours( date.getHours() + 12 );
 	}
 

--- a/src/date/parse.js
+++ b/src/date/parse.js
@@ -260,7 +260,7 @@ return function( value, tokens, properties ) {
 		date.setDate( daysOfYear );
 	}
 
-	if ( hour12 && (amPm === "pm" || amPm === "afternoon") ) {
+	if ( hour12 && ( amPm === "pm" || amPm === "afternoon" ) ) {
 		date.setHours( date.getHours() + 12 );
 	}
 


### PR DESCRIPTION
Fixed zh-Hant PM recognition to include 'afternoon' as it alphabetically comes before 'am' - fixes issue where AM and PM were both parsing as the AM datetime because "afternoon" was not being recognized as PM and therefore not adding 12 hours.
