### PR TITLE
DateTimeFormatter: Dynamically augment skeleton

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ before_install:
 install:
 - npm install
 - bower install
+sudo: false

--- a/src/date/expand-pattern.js
+++ b/src/date/expand-pattern.js
@@ -92,7 +92,7 @@ return function( options, cldr ) {
 			}
 		}
 
-		distance *= 1.25 * (maxLength - minLength + 1);
+		distance *= 1.25 * ( maxLength - minLength + 1 );
 
 		if ( formatA.length === formatB.length ) {
 			distance *= 0.5;

--- a/src/date/expand-pattern.js
+++ b/src/date/expand-pattern.js
@@ -27,7 +27,7 @@ define([
  */
 
 return function( options, cldr ) {
-	var dateSkeleton, result, skeleton, timeSkeleton, type;
+	var dateSkeleton, result, skeleton, timeSkeleton, type, dateTimeSkeleton;
 
 	function combineDateTime( type, datePattern, timePattern ) {
 		return formatMessage(
@@ -56,9 +56,13 @@ return function( options, cldr ) {
 				});
 			}
 
-			ratedFormats.sort( function( formatA, formatB ) {
-				return formatA.rate - formatB.rate;
-			});
+			ratedFormats = ratedFormats
+				.filter( function( format ) {
+					return format.rate > -1;
+				} )
+				.sort( function( formatA, formatB ) {
+					return formatA.rate - formatB.rate;
+				});
 
 			if ( ratedFormats.length ) {
 				pattern = augmentFormat( skeleton, ratedFormats[0].pattern );
@@ -68,64 +72,93 @@ return function( options, cldr ) {
 		return pattern;
 	}
 
-	function compareFormats( formatA, formatB ) {
-		var distance, maxLength, minLength, index;
+	function repeatStr( str, count ) {
+		var i, result = "";
+		for ( i = 0; i < count; i++ ) {
+			result = result + str;
+		}
+		return result;
+	}
 
-		maxLength = Math.max( formatA.length, formatB.length );
-		minLength = Math.min( formatA.length, formatB.length );
-		distance = maxLength / minLength;
+	function normalizePatternType( char ) {
+		switch ( char ) {
+			case "e":
+			case "E":
+			case "c":
+				return "e";
+
+			case "M":
+			case "L":
+				return "L";
+
+			default:
+				return char;
+		}
+	}
+
+	function compareFormats( formatA, formatB ) {
+		var distance,
+			typeA,
+			typeB,
+			matchFound,
+			i,
+			j;
+
+		if ( formatA === formatB ) {
+			return 0;
+		}
 
 		formatA = formatA.match( datePatternRe );
 		formatB = formatB.match( datePatternRe );
-		maxLength = Math.max( formatA.length, formatB.length );
-		minLength = Math.min( formatA.length, formatB.length );
-
-		for ( index = 0; index < minLength; index++ ) {
-			if ( formatA[index].charAt( 0 ) === formatB[index].charAt( 0 ) ) {
-				if ( formatA[index].length === formatB[index].length ) {
-					distance *= 0.25;
-				} else {
-					distance *= 0.75;
-				}
-			} else {
-				distance *= 1.25;
-			}
-		}
-
-		distance *= 1.25 * ( maxLength - minLength + 1 );
-
 		if ( formatA.length === formatB.length ) {
-			distance *= 0.5;
+			distance = 1;
+			for ( i = 0; i < formatA.length; i++ ) {
+				typeA = normalizePatternType( formatA[i].charAt( 0 ) );
+				typeB = null;
+				matchFound = false;
+				for ( j = 0; j < formatB.length; j++ ) {
+					typeB = normalizePatternType( formatB[j].charAt( 0 ) );
+					if ( typeA === typeB ) {
+						break;
+					} else {
+						typeB = null;
+					}
+				}
+				if ( null === typeB ) {
+					return -1;
+				}
+				distance = distance + Math.abs( formatA[i].length - formatB[j].length );
+				if ( formatA[i].charAt( 0 ) !== formatB[j].charAt( 0 ) ) {
+					distance = distance + 1;
+				}
+			}
+			return distance;
 		}
-
-		return distance;
+		return -1;
 	}
 
 	function augmentFormat( requestedSkeleton, bestMatchFormat ) {
-		var originalBestMatchFormat, index, type, tempIndex;
+		var i, j, matchedType, matchedLength, requestedType, requestedLength;
 
-		originalBestMatchFormat = bestMatchFormat;
 		requestedSkeleton = requestedSkeleton.match( datePatternRe );
 		bestMatchFormat = bestMatchFormat.match( datePatternRe );
 
-		for ( index in bestMatchFormat ) {
-			type = bestMatchFormat[index].charAt( 0 );
-
-			for ( tempIndex in requestedSkeleton ) {
-				if ( type === requestedSkeleton[tempIndex].charAt( 0 ) ) {
-					bestMatchFormat[index] = requestedSkeleton[tempIndex];
-					break;
+		for ( i = 0; i < bestMatchFormat.length; i++ ) {
+			matchedType = bestMatchFormat[i].charAt( 0 );
+			matchedLength = bestMatchFormat[i].length;
+			for ( j = 0; j < requestedSkeleton.length; j++ ) {
+				requestedType = requestedSkeleton[j].charAt( 0 );
+				requestedLength = requestedSkeleton[j].length;
+				if (
+					normalizePatternType( matchedType ) === normalizePatternType( requestedType ) &&
+					matchedLength < requestedLength
+				) {
+					bestMatchFormat[i] = repeatStr( matchedType, requestedLength );
 				}
 			}
 		}
 
-		bestMatchFormat = bestMatchFormat.join( "" );
-
-		if ( bestMatchFormat === originalBestMatchFormat ) {
-			bestMatchFormat = requestedSkeleton.join( "" );
-		}
-
-		return bestMatchFormat;
+		return bestMatchFormat.join( "" );
 	}
 
 	switch ( true ) {
@@ -138,28 +171,37 @@ return function( options, cldr ) {
 			if ( !result ) {
 				timeSkeleton = skeleton.split( /[^hHKkmsSAzZOvVXx]/ ).slice( -1 )[ 0 ];
 				dateSkeleton = skeleton.split( /[^GyYuUrQqMLlwWdDFgEec]/ )[ 0 ];
-				if ( /(MMMM|LLLL).*[Ec]/.test( dateSkeleton ) ) {
-					type = "full";
-				} else if ( /MMMM/g.test( dateSkeleton ) ) {
-					type = "long";
-				} else if ( /MMM/g.test( dateSkeleton ) || /LLL/g.test( dateSkeleton ) ) {
-					type = "medium";
+				dateTimeSkeleton = getBestMatchPattern(
+					"dates/calendars/gregorian/dateTimeFormats/availableFormats",
+					skeleton
+				);
+				if ( dateTimeSkeleton ) {
+					result = dateTimeSkeleton;
 				} else {
-					type = "short";
-				}
-				dateSkeleton = getBestMatchPattern(
-					"dates/calendars/gregorian/dateTimeFormats/availableFormats",
-					dateSkeleton
-				);
-				timeSkeleton = getBestMatchPattern(
-					"dates/calendars/gregorian/dateTimeFormats/availableFormats",
-					timeSkeleton
-				);
+					dateSkeleton = getBestMatchPattern(
+						"dates/calendars/gregorian/dateTimeFormats/availableFormats",
+						dateSkeleton
+					);
+					timeSkeleton = getBestMatchPattern(
+						"dates/calendars/gregorian/dateTimeFormats/availableFormats",
+						timeSkeleton
+					);
 
-				if ( dateSkeleton && timeSkeleton ) {
-					result = combineDateTime( type, dateSkeleton, timeSkeleton );
-				} else {
-					result = dateSkeleton || timeSkeleton;
+					if ( /(MMMM|LLLL).*[Ec]/.test( dateSkeleton ) ) {
+						type = "full";
+					} else if ( /MMMM/g.test( dateSkeleton ) ) {
+						type = "long";
+					} else if ( /MMM/g.test( dateSkeleton ) || /LLL/g.test( dateSkeleton ) ) {
+						type = "medium";
+					} else {
+						type = "short";
+					}
+
+					if ( dateSkeleton && timeSkeleton ) {
+						result = combineDateTime( type, dateSkeleton, timeSkeleton );
+					} else {
+						result = dateSkeleton || timeSkeleton;
+					}
 				}
 			}
 			break;

--- a/test/functional/date/date-formatter.js
+++ b/test/functional/date/date-formatter.js
@@ -60,6 +60,15 @@ QUnit.test( "should return a formatter", function( assert ) {
 	assert.equal( Globalize.dateFormatter({ skeleton: "yQQQhm" })( date ), "Q3 2010, 5:35 PM" );
 });
 
+QUnit.test( "should augment a skeleton", function( assert ) {
+	extraSetup();
+
+	assert.equal( Globalize.dateFormatter({ skeleton: "yMMMMd" })( date ), "September 15, 2010" );
+	assert.equal( Globalize.dateFormatter({ skeleton: "MMMMd" })( date ), "September 15" );
+	assert.equal( Globalize.dateFormatter({ skeleton: "MMMM" })( date ), "September" );
+	assert.equal( Globalize.dateFormatter({ skeleton: "EEEE" })( date ), "Wednesday" );
+});
+
 QUnit.test( "should allow for runtime compilation", function( assert ) {
 	extraSetup();
 

--- a/test/unit/date/expand-pattern.js
+++ b/test/unit/date/expand-pattern.js
@@ -40,4 +40,11 @@ QUnit.test( "should expand {raw: \"<pattern>\"}", function( assert ) {
 	assert.equal( expandPattern( { raw: "MMM d" }, en ), "MMM d" );
 });
 
+QUnit.test( "should augment {skeleton: \"<skeleton>\"}", function( assert ) {
+	assert.equal( expandPattern( { skeleton: "yMMMMd" }, de ), "d. MMMM y" );
+	assert.equal( expandPattern( { skeleton: "MMMMd" }, de ), "d. MMMM" );
+	assert.equal( expandPattern( { skeleton: "MMMM" }, de ), "MMMM" );
+	assert.equal( expandPattern( { skeleton: "EEEE" }, de ), "EEEE" );
+});
+
 });

--- a/test/unit/date/expand-pattern.js
+++ b/test/unit/date/expand-pattern.js
@@ -3,25 +3,83 @@ define([
 	"src/date/expand-pattern",
 	"json!cldr-data/main/de/ca-gregorian.json",
 	"json!cldr-data/main/en/ca-gregorian.json",
+	"json!cldr-data/main/ru/ca-gregorian.json",
 	"json!cldr-data/supplemental/likelySubtags.json",
 
 	"cldr/event",
 	"cldr/supplemental"
-], function( Cldr, expandPattern, deCaGregorian, enCaGregorian, likelySubtags ) {
+], function( Cldr, expandPattern, deCaGregorian, enCaGregorian, ruCaGregorian, likelySubtags ) {
 
-var de, en;
+var de, en, ru;
 
-Cldr.load( deCaGregorian, enCaGregorian, likelySubtags );
+Cldr.load( deCaGregorian, enCaGregorian, ruCaGregorian, likelySubtags );
 
 de = new Cldr( "de" );
 en = new Cldr( "en" );
+ru = new Cldr( "ru" );
+
+/**
+ * Test actual patterns here
+ * @see https://ssl.icu-project.org/icu4jweb/flexTest.jsp
+ */
 
 QUnit.module( "Date Expand Pattern" );
 
+
 QUnit.test( "should expand {skeleton: \"<skeleton>\"}", function( assert ) {
-	assert.equal( expandPattern( { skeleton: "GyMMMEd" }, en ), "E, MMM d, y G" );
-	assert.equal( expandPattern( { skeleton: "GyMMMEdhms" }, en ), "E, MMM d, y G, h:mm:ss a" );
-	assert.equal( expandPattern( { skeleton: "MMMMEdhm" }, de ), "E, d. MMMM 'um' h:mm a" );
+	var cldrs = {
+		en: en,
+		de: de,
+		ru: ru
+	};
+	var cases = {
+		en: {
+			"GyMMMEd": "E, MMM d, y G",
+			"GyMMMEdhms": "E, MMM d, y G, h:mm:ss a",
+			"MMMMEdhm": "E, MMMM d 'at' h:mm a",
+			"hhmm": "hh:mm a",
+			"HHmm": "HH:mm",
+			"EHmss": "E HH:mm:ss",
+			"MMMMh": "LLLL, h a"
+		},
+		de: {
+			"yMMMMd": "d. MMMM y",
+			"MMMMd": "d. MMMM",
+			"MMMM": "LLLL",
+			"MMMMy": "MMMM y",
+			"EEEE": "cccc",
+			"cccc": "cccc",
+			"EEEEMMMMd": "EEEE, d. MMMM",
+			"ccccMMMMd": "EEEE, d. MMMM",
+			"HHmm": "HH:mm",
+			"EEEEHHmm": "EEEE, HH:mm",
+			"EEEEHmm": "EEEE, HH:mm",
+			"ccccHmm": "EEEE, HH:mm",
+			"MMMMEdhm": "E, d. MMMM 'um' h:mm a"
+		},
+		ru: {
+			"yMMMMd": "d MMMM y 'г'.",
+			"MMMMd": "d MMMM",
+			"MMMM": "LLLL",
+			"MMMMy": "LLLL y 'г'.",
+			"EEEE": "cccc",
+			"cccc": "cccc",
+			"EEEEMMMMd": "cccc, d MMMM",
+			"ccccMMMMd": "cccc, d MMMM",
+			"HHmm": "HH:mm",
+			"EEEEHHmm": "EEEE HH:mm",
+			"EEEEHmm": "EEEE HH:mm",
+			"ccccHHmm": "EEEE HH:mm",
+			"ccccHmm": "EEEE HH:mm",
+			"MMMMEdhm": "ccc, d MMMM, h:mm a"
+		}
+	};
+	Object.keys( cases ).forEach( function( locale ) {
+		Object.keys( cases[locale] ).forEach( function( skeleton ) {
+			var expected = cases[locale][skeleton];
+			assert.equal( expandPattern( {skeleton: skeleton}, cldrs[locale] ), expected, locale + ", " + skeleton );
+		} );
+	} );
 });
 
 QUnit.test( "should expand {date: \"(full, ...)\"}", function( assert ) {
@@ -38,13 +96,6 @@ QUnit.test( "should expand {datetime: \"(full, ...)\"}", function( assert ) {
 
 QUnit.test( "should expand {raw: \"<pattern>\"}", function( assert ) {
 	assert.equal( expandPattern( { raw: "MMM d" }, en ), "MMM d" );
-});
-
-QUnit.test( "should augment {skeleton: \"<skeleton>\"}", function( assert ) {
-	assert.equal( expandPattern( { skeleton: "yMMMMd" }, de ), "d. MMMM y" );
-	assert.equal( expandPattern( { skeleton: "MMMMd" }, de ), "d. MMMM" );
-	assert.equal( expandPattern( { skeleton: "MMMM" }, de ), "MMMM" );
-	assert.equal( expandPattern( { skeleton: "EEEE" }, de ), "EEEE" );
 });
 
 });


### PR DESCRIPTION
Fixes #271 
This is rework of #462.

I have implemented another skeleton pattern comparison algorithm, which fixes a lot of issues I have found in #462 implementation.

Also I have added a lot of tests, which were tested manually across [Intl.DateTimeFormat](https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat) and [ICU Flex Test](https://ssl.icu-project.org/icu4jweb/flexTest.jsp).

But not all resulst same from Flex Test and my implementation. This is difference table:

| Skeleton | Flex Pattern | Globalize Pattern | Comment |
| --- | --- | --- | --- |
| `GyMMMEd` | [`EEE, MMM d, y G`](https://ssl.icu-project.org/icu4jweb/flexTest.jsp?pat=GyMMMEd&_=en) | `E, MMM d, y G` | There is explicit available format in cldr-data, which used by globalize |
| `GyMMMEdhms` | [`EEE, MMM d, y G, h:mm:ss a`](https://ssl.icu-project.org/icu4jweb/flexTest.jsp?pat=GyMMMEdhms&_=en) | `E, MMM d, y G, h:mm:ss a` | This is combined `GyMMMEd` and `hms` patterns, which are both available in cldr-data and merged with `dateTimeFormat.medium` |
| `hhmm` | [`h:mm a`](https://ssl.icu-project.org/icu4jweb/flexTest.jsp?pat=hhmm&_=en) | `hh:mm a` | Globalize expand matched `h:mm a` to `hh:mm a` because user requested `hh` in his pattern |
| `EHmms` | [`EEE HH:mm:ss`](https://ssl.icu-project.org/icu4jweb/flexTest.jsp?pat=EHmss&_=en) | `E HH:mm:ss` | There is explicit entry in cldr-data, which matches `EHms` to `E HH:mm:ss`. Because in result pattern `mm` already present, we don't need to augment any more. |

And all other differences are similar. In fact, I am really can not understand, why flexTest augments `E` to `EEE`, if you know why please tell me :-)
