### PR TITLE
Currency: support symbol-alt-narrow

### DIFF
--- a/src/currency/symbol-properties.js
+++ b/src/currency/symbol-properties.js
@@ -15,11 +15,11 @@ return function( currency, cldr, options ) {
 			"[:digit:]": /\d/,
 			"[:^S:]": regexpNotS
 		},
-		symbol = cldr.main([
+		currencySymbols = cldr.main([
 			"numbers/currencies",
-			currency,
-			"symbol"
-		]);
+			currency
+		]),
+        symbol = currencySymbols[options.symbolForm || "symbol"] || currencySymbols.symbol;
 
 	currencySpacing = [ "beforeCurrency", "afterCurrency" ].map(function( position ) {
 		return cldr.main([

--- a/test/functional/currency/currency-formatter.js
+++ b/test/functional/currency/currency-formatter.js
@@ -19,7 +19,8 @@ define([
 
 var accounting = { style: "accounting" },
 	code = { style: "code" },
-	name = { style: "name" },
+    name = { style: "name" },
+	narrow = { symbolForm: "symbol-alt-narrow" },
 	teslaS = 69900;
 
 function extraSetup() {
@@ -93,6 +94,15 @@ QUnit.test( "should return a currency formatter", function( assert ) {
 	assert.equal( zh.currencyFormatter( "USD", name )( teslaS ), "69,900.00美元" );
 
 	assert.equal( Globalize.currencyFormatter( "USD", accounting )( -1 ), "($1.00)" );
+});
+
+QUnit.test( "should use the supplied symbolForm, falling back to standard if none is found", function( assert ) {
+
+    extraSetup();
+
+    assert.equal( Globalize.currencyFormatter( "HKD", narrow )( teslaS ), "$69,900.00" );
+    assert.equal( Globalize.currencyFormatter( "CHF", narrow )( teslaS ), "CHF 69,900.00" );
+
 });
 
 // The number of decimal places and the rounding for each currency is not locale-specific data.


### PR DESCRIPTION
Adds support for alternative symbols via 'symbolForm' option

Fixes #479
