### PR TITLE
Message: fix selectOrdinal.

### DIFF
--- a/examples/amd-bower/main.js
+++ b/examples/amd-bower/main.js
@@ -36,6 +36,7 @@ require([
 	"json!cldr-data/supplemental/currencyData.json",
 	"json!cldr-data/supplemental/likelySubtags.json",
 	"json!cldr-data/supplemental/plurals.json",
+	"json!cldr-data/supplemental/ordinals.json",
 	"json!cldr-data/supplemental/timeData.json",
 	"json!cldr-data/supplemental/weekData.json",
 	"json!messages/en.json",
@@ -49,7 +50,7 @@ require([
 	"globalize/relative-time",
 	"globalize/unit"
 ], function( Globalize, enGregorian, enCurrencies, enDateFields, enNumbers, enUnits, currencyData,
-	likelySubtags, pluralsData, timeData, weekData, messages ) {
+	likelySubtags, pluralsData, ordinalsData, timeData, weekData, messages ) {
 
 	var en, like, number;
 
@@ -63,6 +64,7 @@ require([
 		enUnits,
 		likelySubtags,
 		pluralsData,
+		ordinalsData,
 		timeData,
 		weekData
 	);

--- a/examples/app-npm-webpack/package.json
+++ b/examples/app-npm-webpack/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "devDependencies": {
     "cldr-data": ">=25",
+    "globalize": "^1.1.1",
     "globalize-webpack-plugin": "0.3.x",
     "html-webpack-plugin": "^1.1.0",
     "nopt": "^3.0.3",

--- a/examples/globalize-compiler/cldr.json
+++ b/examples/globalize-compiler/cldr.json
@@ -142,6 +142,14 @@
 				"pluralRule-count-one": "i = 1 and v = 0 @integer 1",
 				"pluralRule-count-other": " @integer 0, 2~16, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0~1.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …"
 			}
+		},
+		"plurals-type-ordinal": {
+			"en": {
+				"pluralRule-count-one": "n % 10 = 1 and n % 100 != 11 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …",
+				"pluralRule-count-two": "n % 10 = 2 and n % 100 != 12 @integer 2, 22, 32, 42, 52, 62, 72, 82, 102, 1002, …",
+				"pluralRule-count-few": "n % 10 = 3 and n % 100 != 13 @integer 3, 23, 33, 43, 53, 63, 73, 83, 103, 1003, …",
+				"pluralRule-count-other": " @integer 0, 4~18, 100, 1000, 10000, 100000, 1000000, …"
+			}
 		}
 	}
 }

--- a/examples/node-npm/main.js
+++ b/examples/node-npm/main.js
@@ -11,6 +11,7 @@ Globalize.load(
 	require( "cldr-data/supplemental/currencyData" ),
 	require( "cldr-data/supplemental/likelySubtags" ),
 	require( "cldr-data/supplemental/plurals" ),
+	require( "cldr-data/supplemental/ordinals" ),
 	require( "cldr-data/supplemental/timeData" ),
 	require( "cldr-data/supplemental/weekData" )
 );

--- a/examples/plain-javascript/index.html
+++ b/examples/plain-javascript/index.html
@@ -209,6 +209,14 @@
             "pluralRule-count-one": "i = 1 and v = 0 @integer 1",
             "pluralRule-count-other": " @integer 0, 2~16, 100, 1000, 10000, 100000, 1000000, … @decimal 0.0~1.5, 10.0, 100.0, 1000.0, 10000.0, 100000.0, 1000000.0, …"
           }
+        },
+        "plurals-type-ordinal": {
+          "en": {
+            "pluralRule-count-one": "n % 10 = 1 and n % 100 != 11 @integer 1, 21, 31, 41, 51, 61, 71, 81, 101, 1001, …",
+            "pluralRule-count-two": "n % 10 = 2 and n % 100 != 12 @integer 2, 22, 32, 42, 52, 62, 72, 82, 102, 1002, …",
+            "pluralRule-count-few": "n % 10 = 3 and n % 100 != 13 @integer 3, 23, 33, 43, 53, 63, 73, 83, 103, 1003, …",
+            "pluralRule-count-other": " @integer 0, 4~18, 100, 1000, 10000, 100000, 1000000, …"
+          }
         }
       }
     });

--- a/src/common/validate/parameter-type/plural-type.js
+++ b/src/common/validate/parameter-type/plural-type.js
@@ -6,8 +6,8 @@ return function( value, name ) {
 	validateParameterType(
 		value,
 		name,
-		value === undefined || value === "cardinal" || value === "ordinal",
-		"String \"cardinal\" or \"ordinal\""
+		value === undefined || value === "cardinal" || value === "ordinal" || value === "both",
+		"String \"cardinal\" or \"ordinal\" or \"both\""
 	);
 };
 

--- a/src/message.js
+++ b/src/message.js
@@ -84,7 +84,7 @@ Globalize.prototype.messageFormatter = function( path ) {
 
 	// Is plural module present? Yes, use its generator. Nope, use an error generator.
 	pluralGenerator = this.plural !== undefined ?
-		this.pluralGenerator() :
+		this.pluralGenerator( { type: "both" } ) :
 		createErrorPluralModulePresence;
 
 	formatter = new MessageFormat( cldr.locale, pluralGenerator ).compile( message );

--- a/src/message/formatter-runtime-bind.js
+++ b/src/message/formatter-runtime-bind.js
@@ -25,7 +25,8 @@ return function( cldr, messageformatter ) {
 
 		output.replace( /pluralFuncs(\[([^\]]+)\]|\.([a-zA-Z]+))/, function( match ) {
 			args.pluralFuncs = "{" +
-				"\"" + locale + "\": Globalize(\"" + locale + "\").pluralGenerator()" +
+				"\"" + locale + "\": Globalize(\"" + locale + "\")." +
+				"pluralGenerator( { type: \"both\" } )" +
 				"}";
 			return match;
 		});

--- a/src/plural.js
+++ b/src/plural.js
@@ -48,7 +48,7 @@ Globalize.prototype.plural = function( value, options ) {
  */
 Globalize.pluralGenerator =
 Globalize.prototype.pluralGenerator = function( options ) {
-	var args, cldr, isOrdinal, plural, returnFn, type;
+	var args, cldr, isOrdinal, isCardinal, plural, returnFn, type;
 
 	validateParameterTypePlainObject( options, "options" );
 
@@ -62,18 +62,29 @@ Globalize.prototype.pluralGenerator = function( options ) {
 
 	validateDefaultLocale( cldr );
 
-	isOrdinal = type === "ordinal";
+	isOrdinal = type === "ordinal" || type === "both";
+	isCardinal = type === "cardinal" || type === "both";
 
 	cldr.on( "get", validateCldr );
-	cldr.supplemental([ "plurals-type-" + type, "{language}" ]);
+	if ( isOrdinal ) {
+		cldr.supplemental([ "plurals-type-ordinal", "{language}" ]);
+	}
+	if ( isCardinal ) {
+		cldr.supplemental([ "plurals-type-cardinal", "{language}" ]);
+	}
 	cldr.off( "get", validateCldr );
 
 	MakePlural.rules = {};
-	MakePlural.rules[ type ] = cldr.supplemental( "plurals-type-" + type );
+	if ( isOrdinal ) {
+		MakePlural.rules.ordinal = cldr.supplemental( "plurals-type-ordinal" );
+	}
+	if ( isCardinal ) {
+		MakePlural.rules.cardinal = cldr.supplemental( "plurals-type-cardinal" );
+	}
 
 	plural = new MakePlural( cldr.attributes.language, {
 		"ordinals": isOrdinal,
-		"cardinals": !isOrdinal
+		"cardinals": isCardinal
 	});
 
 	returnFn = pluralGeneratorFn( plural );

--- a/src/plural/generator-fn.js
+++ b/src/plural/generator-fn.js
@@ -4,11 +4,11 @@ define([
 ], function( validateParameterPresence, validateParameterTypeNumber ) {
 
 return function( plural ) {
-	return function pluralGenerator( value ) {
+	return function pluralGenerator( value, ord ) {
 		validateParameterPresence( value, "value" );
 		validateParameterTypeNumber( value, "value" );
 
-		return plural( value );
+		return plural( value, ord );
 	};
 };
 

--- a/test/functional/message/format-message.js
+++ b/test/functional/message/format-message.js
@@ -2,16 +2,18 @@ define([
 	"globalize",
 	"json!cldr-data/supplemental/likelySubtags.json",
 	"json!cldr-data/supplemental/plurals.json",
+	"json!cldr-data/supplemental/ordinals.json",
 	"../../util",
 
 	"globalize/message",
 	"globalize/plural"
-], function( Globalize, likelySubtags, plurals, util ) {
+], function( Globalize, likelySubtags, plurals, ordinals, util ) {
 
 QUnit.module( ".formatMessage( path [, variables] )", {
 	setup: function() {
 		Globalize.load( likelySubtags );
 		Globalize.load( plurals );
+		Globalize.load( ordinals );
 		Globalize.loadMessages({
 			en: {
 				greetings: {

--- a/test/functional/message/message-formatter.js
+++ b/test/functional/message/message-formatter.js
@@ -2,12 +2,13 @@ define([
 	"globalize",
 	"json!cldr-data/supplemental/likelySubtags.json",
 	"json!cldr-data/supplemental/plurals.json",
+	"json!cldr-data/supplemental/ordinals.json",
 	"../../util",
 
 	"cldr/unresolved",
 	"globalize/message",
 	"globalize/plural"
-], function( Globalize, likelySubtags, plurals, util ) {
+], function( Globalize, likelySubtags, plurals, ordinals, util ) {
 
 QUnit.assert.messageFormatter = function( locale, path, variables, expected ) {
 	if ( arguments.length === 3 ) {
@@ -28,6 +29,7 @@ QUnit.module( ".messageFormatter( path )", {
 	setup: function() {
 		Globalize.load( likelySubtags );
 		Globalize.load( plurals );
+		Globalize.load( ordinals );
 		Globalize.loadMessages({
 			root: {
 				amen: "Amen"
@@ -60,7 +62,11 @@ QUnit.module( ".messageFormatter( path )", {
 					"    one {one task}",
 					"  other {# tasks}",
 					"} remaining"
-				]
+				],
+				ordinal: [
+					"{cat, selectordinal, one{#st} two{#nd} few{#rd} other{#th} }",
+					"category"
+				],
 			},
 			"en-GB": {},
 			fr: {},
@@ -173,6 +179,23 @@ QUnit.test( "should support ICU message format", function( assert ) {
 	}), "You and Beethoven liked this" );
 
 	assert.equal( like({ count: 3 }), "You and 2 others liked this" );
+
+	// Selectordinal
+	assert.messageFormatter( "en", "ordinal", {
+		cat: 1,
+	}, "1st category" );
+
+	assert.messageFormatter( "en", "ordinal", {
+		cat: 2,
+	}, "2nd category" );
+
+	assert.messageFormatter( "en", "ordinal", {
+		cat: 3,
+	}, "3rd category" );
+
+	assert.messageFormatter( "en", "ordinal", {
+		cat: 4,
+	}, "4th category" );
 });
 
 // Reference #473
@@ -213,7 +236,7 @@ QUnit.test( "should allow for runtime compilation", function( assert ) {
 		function( runtimeArgs ) {
 			assert.equal(
 				runtimeArgs[ 0 ].toString(),
-				"(function( number, plural, pluralFuncs ) {\n  return function (d) { return plural(d.count, 1, pluralFuncs.en, { 0: function() { return \"Be the first to like this\";}, 1: function() { return \"You liked this\";}, one: function() { return \"You and \" + d.someone + \" liked this\";}, other: function() { return \"You and \" + number(d.count, 1) + \" others liked this\";} }); }\n})(messageFormat.number, messageFormat.plural, {\"en\": Globalize(\"en\").pluralGenerator()})"
+				"(function( number, plural, pluralFuncs ) {\n  return function (d) { return plural(d.count, 1, pluralFuncs.en, { 0: function() { return \"Be the first to like this\";}, 1: function() { return \"You liked this\";}, one: function() { return \"You and \" + d.someone + \" liked this\";}, other: function() { return \"You and \" + number(d.count, 1) + \" others liked this\";} }); }\n})(messageFormat.number, messageFormat.plural, {\"en\": Globalize(\"en\").pluralGenerator( { type: \"both\" } )})"
 			);
 		}
 	);


### PR DESCRIPTION
The plural fuction used for messages only supported cardinals,
not ordinals. This meant that selectOrdinal used the cardinal
rules, not the ordinal rules.

If the type option passed to Globalize.pluralGenerator is "both",
the returned function accepts a second parameter. If this
parameter is true, the function will return the ordinal category
instead of the cardinal category.
This is how messageformat.js expects the plural function to work.

This introduces a minor BC break, because supplemental/ordinals.json must be loaded (I've fixed all the examples), although [the documentation does suggest you need both](https://github.com/jquery/globalize#2-cldr-content).
