### PR TITLE
Fix npmignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .sizecache.json
-bower_components/
-external
-node_modules
+.tmp-globalize-webpack/
+dist/.build/
+external/
+node_modules/
 tmp/

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,0 @@
-generator/

--- a/examples/amd-bower/.gitignore
+++ b/examples/amd-bower/.gitignore
@@ -1,0 +1,1 @@
+bower_components/

--- a/examples/amd-bower/bower.json
+++ b/examples/amd-bower/bower.json
@@ -1,7 +1,8 @@
 {
   "name": "globalize-hello-world-amd-bower",
   "dependencies": {
-    "globalize": "1.1.x"
+    "cldr-data": "*",
+    "globalize": ">=1.2.0-a <2.0.0"
   },
   "devDependencies": {
     "requirejs": "2.1.14",

--- a/examples/app-npm-webpack/.gitignore
+++ b/examples/app-npm-webpack/.gitignore
@@ -1,2 +1,1 @@
 dist/
-.tmp-globalize-webpack/

--- a/examples/app-npm-webpack/package.json
+++ b/examples/app-npm-webpack/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "devDependencies": {
     "cldr-data": ">=25",
+    "globalize": ">=1.2.0-a <2.0.0",
     "globalize-webpack-plugin": "0.3.x",
     "html-webpack-plugin": "^1.1.0",
     "nopt": "^3.0.3",

--- a/examples/globalize-compiler/package.json
+++ b/examples/globalize-compiler/package.json
@@ -6,7 +6,7 @@
   },
   "devDependencies": {
     "cldr-data": ">=25",
-    "globalize": "1.1.x",
+    "globalize": ">=1.2.0-a <2.0.0",
     "globalize-compiler": "^0.2.1",
     "jquery": "latest"
   }

--- a/examples/node-npm/package.json
+++ b/examples/node-npm/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "dependencies": {
     "cldr-data": "latest",
-    "globalize": "1.1.x"
+    "globalize": ">=1.2.0-a <2.0.0"
   }
 }

--- a/examples/plain-javascript/.gitignore
+++ b/examples/plain-javascript/.gitignore
@@ -1,0 +1,2 @@
+cldrjs/
+globalize/

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "files": [
     "CONTRIBUTING.md",
     "dist/",
+    "!dist/.build",
     "doc/",
     "examples/",
     "LICENSE.txt",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,10 @@
     "!dist/.build",
     "doc/",
     "examples/",
+    "!examples/**/bower_components",
+    "!examples/**/.tmp-globalize-webpack",
+    "!examples/plain-javascript/cldrjs",
+    "!examples/plain-javascript/globalize",
     "LICENSE.txt",
     "README.md"
   ],


### PR DESCRIPTION
I've done several tests and was surprised by the several failed attempts to get files ignored in published package.

1. Removed the invalid existing `.npmignore`.
1. Merged the various `.gitignore`s (from examples) into `/.gitignore`, but it didn't help. I don't understand why these entries are simply not taken into account by `npm` (tested v3.9.6 from node 5).
1. Used negate expressions in package.json files entry worked, although it goes against recommendation:

> "The consequences are undefined" if you try to negate any of the files entries (that is, "!foo.js"). Please don't. Use .npmignore.

https://github.com/npm/npm/wiki/Files-and-Ignores#details

PS: By the way, I used `tar -tf $(npm pack)` to test a publish, a workaround for a dry run.