### PR TITLE
Package.json: bump grunt-contrib-jshint to 0.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "grunt-contrib-clean": "0.6.0",
     "grunt-contrib-connect": "0.8.0",
     "grunt-contrib-copy": "0.6.0",
-    "grunt-contrib-jshint": "0.10.0",
+    "grunt-contrib-jshint": "0.11.1",
     "grunt-contrib-qunit": "0.7.0",
     "grunt-contrib-requirejs": "0.4.4",
     "grunt-contrib-uglify": "0.6.0",


### PR DESCRIPTION
This fixes https://github.com/jshint/jshint/issues/2922

Fixes #666