### PR TITLE
Add "use strict" declarations to runtime files

### DIFF
--- a/src/build/intro-core-runtime.js
+++ b/src/build/intro-core-runtime.js
@@ -15,6 +15,8 @@
  */
 (function( root, factory ) {
 
+	"use strict";
+
 	// UMD returnExports
 	if ( typeof define === "function" && define.amd ) {
 
@@ -30,3 +32,5 @@
 		root.Globalize = factory();
 	}
 }( this, function() {
+
+	"use strict";

--- a/src/build/intro-currency-runtime.js
+++ b/src/build/intro-currency-runtime.js
@@ -15,6 +15,8 @@
  */
 (function( root, factory ) {
 
+	"use strict";
+
 	// UMD returnExports
 	if ( typeof define === "function" && define.amd ) {
 
@@ -36,6 +38,8 @@
 		factory( root.Globalize );
 	}
 }(this, function( Globalize ) {
+
+	"use strict";
 
 var formatMessage = Globalize._formatMessage,
 	runtimeKey = Globalize._runtimeKey,

--- a/src/build/intro-date-runtime.js
+++ b/src/build/intro-date-runtime.js
@@ -15,6 +15,8 @@
  */
 (function( root, factory ) {
 
+	"use strict";
+
 	// UMD returnExports
 	if ( typeof define === "function" && define.amd ) {
 
@@ -36,6 +38,8 @@
 		factory( root.Globalize );
 	}
 }(this, function( Globalize ) {
+
+	"use strict";
 
 var createErrorUnsupportedFeature = Globalize._createErrorUnsupportedFeature,
 	regexpEscape = Globalize._regexpEscape,

--- a/src/build/intro-message-runtime.js
+++ b/src/build/intro-message-runtime.js
@@ -15,6 +15,8 @@
  */
 (function( root, factory ) {
 
+	"use strict";
+
 	// UMD returnExports
 	if ( typeof define === "function" && define.amd ) {
 
@@ -32,6 +34,8 @@
 		factory( root.Globalize );
 	}
 }(this, function( Globalize ) {
+
+	"use strict";
 
 var runtimeKey = Globalize._runtimeKey,
 	validateParameterType = Globalize._validateParameterType;

--- a/src/build/intro-number-runtime.js
+++ b/src/build/intro-number-runtime.js
@@ -15,6 +15,8 @@
  */
 (function( root, factory ) {
 
+	"use strict";
+
 	// UMD returnExports
 	if ( typeof define === "function" && define.amd ) {
 
@@ -32,6 +34,8 @@
 		factory( root.Globalize );
 	}
 }(this, function( Globalize ) {
+
+	"use strict";
 
 var createError = Globalize._createError,
 	regexpEscape = Globalize._regexpEscape,

--- a/src/build/intro-plural-runtime.js
+++ b/src/build/intro-plural-runtime.js
@@ -15,6 +15,8 @@
  */
 (function( root, factory ) {
 
+	"use strict";
+
 	// UMD returnExports
 	if ( typeof define === "function" && define.amd ) {
 
@@ -32,6 +34,8 @@
 		factory( root.Globalize );
 	}
 }(this, function( Globalize ) {
+
+	"use strict";
 
 var runtimeKey = Globalize._runtimeKey,
 	validateParameterPresence = Globalize._validateParameterPresence,

--- a/src/build/intro-relative-time-runtime.js
+++ b/src/build/intro-relative-time-runtime.js
@@ -15,6 +15,8 @@
  */
 (function( root, factory ) {
 
+	"use strict";
+
 	// UMD returnExports
 	if ( typeof define === "function" && define.amd ) {
 
@@ -38,6 +40,8 @@
 		factory( root.Globalize );
 	}
 }(this, function( Globalize ) {
+
+	"use strict";
 
 var formatMessage = Globalize._formatMessage,
 	runtimeKey = Globalize._runtimeKey,

--- a/src/build/intro-unit-runtime.js
+++ b/src/build/intro-unit-runtime.js
@@ -15,6 +15,8 @@
  */
 (function( root, factory ) {
 
+	"use strict";
+
 	// UMD returnExports
 	if ( typeof define === "function" && define.amd ) {
 
@@ -38,6 +40,8 @@
 		factory( root.Globalize );
 	}
 }(this, function( Globalize ) {
+
+	"use strict";
 
 var formatMessage = Globalize._formatMessage,
 	runtimeKey = Globalize._runtimeKey,


### PR DESCRIPTION
Runtime script files are now decorated with `"use strict";` statements to keep them in compliance with standard stylecop and eslint style checks.  Globalize code is already strict mode compliant.  This change will not affect browser compatibility since older browsers will simply ignore the statement.  Currently only modifying the built "runtime" files.

strict mode statements are contained within the module loader and factory function scopes so that they do not interfere with other files loaded in a browser.