### PR TITLE
javascript type attribute not required in HTML5

### DIFF
--- a/demo/demo-datepicker.html
+++ b/demo/demo-datepicker.html
@@ -4,11 +4,11 @@
     <title>Globalization Demo</title>
     <link type="text/css" rel="Stylesheet" href="demo-datepicker.css" />
     <link type="text/css" rel="Stylesheet" href="jquery-ui-1.8.1.custom.css" />
-    <script type="text/javascript" src="../jquery-1.4.4.js"></script>
-    <script type="text/javascript" src="../jquery.global.js"></script>
-    <script type="text/javascript" src="../globinfo/jquery.glob.all.js"></script>
-    <script type="text/javascript" src="jquery.ui.core.js"></script>
-    <script type="text/javascript" src="jquery.ui.datepicker.js"></script>
+    <script src="../jquery-1.4.4.js"></script>
+    <script src="../jquery.global.js"></script>
+    <script src="../globinfo/jquery.glob.all.js"></script>
+    <script src="jquery.ui.core.js"></script>
+    <script src="jquery.ui.datepicker.js"></script>
 </head>
 
 <body>
@@ -23,7 +23,7 @@ And you can view the source from here or keep up to date with it on github, here
 
 
 
-<script type="text/javascript">
+<script>
 function sortByName(map) {
     // converts a dictionary into a sorted dictionary based on obj.name
     var arr = [];

--- a/demo/demo-localize.html
+++ b/demo/demo-localize.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <title>JQuery-global localize demo</title>
-    <script type="text/javascript" src="../jquery-1.4.4.js"></script>
+    <script src="../jquery-1.4.4.js"></script>
     <script src="http://ajax.microsoft.com/ajax/jquery.templates/beta1/jquery.tmpl.js"></script>
-    <script type="text/javascript" src="../jquery.global.js"></script>
-    <script type="text/javascript" src="demo-localize.js"></script>
+    <script src="../jquery.global.js"></script>
+    <script src="demo-localize.js"></script>
 
     <script id="movies-tmpl" type="text/x-jquery-tmpl">
       <h1>{{t "home.desc"}}</h1>

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -3,11 +3,11 @@
 <head>
     <title>Globalization Demo</title>
     <link type="text/css" rel="Stylesheet" href="demo.css" />
-    <script type="text/javascript" src="../jquery-1.4.4.js"></script>
-    <script type="text/javascript" src="jquery.tmpl.js"></script>
-    <script type="text/javascript" src="../jquery.global.js"></script>
-    <script type="text/javascript" src="../globinfo/jquery.glob.all.js"></script>
-    <script type="text/javascript" src="demo.js"></script>
+    <script src="../jquery-1.4.4.js"></script>
+    <script src="jquery.tmpl.js"></script>
+    <script src="../jquery.global.js"></script>
+    <script src="../globinfo/jquery.glob.all.js"></script>
+    <script src="demo.js"></script>
     <script id="formattmpl" type="text/html">
         <tr>
             <th>Number</th>

--- a/generator/jQueryUI/jQueryDatePickerGlob.html
+++ b/generator/jQueryUI/jQueryDatePickerGlob.html
@@ -1,9 +1,9 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!DOCTYPE HTML>
 <html>
 	<head>
 		<title></title>
-        <script type="text/javascript" src="http://code.jquery.com/jquery.js"></script>
-        <script type="text/javascript">
+        <script src="http://code.jquery.com/jquery.js"></script>
+        <script>
         jQuery.datepicker = {
             regional: {
 	            '': { // Default regional settings
@@ -29,66 +29,66 @@
             setDefaults: function() { }
         };
         </script>
-        <script src="../../jquery.glob.js" type="text/javascript"></script>
-        <script src="../../globinfo/jquery.glob.all.min.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-af.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-zh-TW.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-ar.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-az.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-bg.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-bs.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-ca.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-cs.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-da.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-de.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-el.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-en-GB.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-eo.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-es.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-et.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-eu.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-fa.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-fi.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-fo.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-fr-CH.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-fr.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-he.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-hr.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-hu.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-hy.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-id.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-is.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-it.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-ja.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-ko.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-lt.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-lv.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-ms.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-nl.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-no.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-pl.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-pt-BR.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-ro.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-ru.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-sk.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-sl.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-sq.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-sr-SR.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-sr.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-sv.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-ta.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-th.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-tr.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-uk.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-vi.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-zh-CN.js" type="text/javascript"></script>
-        <script src="jquery.ui.datepicker-zh-HK.js" type="text/javascript"></script>
+        <script src="../../jquery.glob.js"></script>
+        <script src="../../globinfo/jquery.glob.all.min.js"></script>
+        <script src="jquery.ui.datepicker-af.js"></script>
+        <script src="jquery.ui.datepicker-zh-TW.js"></script>
+        <script src="jquery.ui.datepicker-ar.js"></script>
+        <script src="jquery.ui.datepicker-az.js"></script>
+        <script src="jquery.ui.datepicker-bg.js"></script>
+        <script src="jquery.ui.datepicker-bs.js"></script>
+        <script src="jquery.ui.datepicker-ca.js"></script>
+        <script src="jquery.ui.datepicker-cs.js"></script>
+        <script src="jquery.ui.datepicker-da.js"></script>
+        <script src="jquery.ui.datepicker-de.js"></script>
+        <script src="jquery.ui.datepicker-el.js"></script>
+        <script src="jquery.ui.datepicker-en-GB.js"></script>
+        <script src="jquery.ui.datepicker-eo.js"></script>
+        <script src="jquery.ui.datepicker-es.js"></script>
+        <script src="jquery.ui.datepicker-et.js"></script>
+        <script src="jquery.ui.datepicker-eu.js"></script>
+        <script src="jquery.ui.datepicker-fa.js"></script>
+        <script src="jquery.ui.datepicker-fi.js"></script>
+        <script src="jquery.ui.datepicker-fo.js"></script>
+        <script src="jquery.ui.datepicker-fr-CH.js"></script>
+        <script src="jquery.ui.datepicker-fr.js"></script>
+        <script src="jquery.ui.datepicker-he.js"></script>
+        <script src="jquery.ui.datepicker-hr.js"></script>
+        <script src="jquery.ui.datepicker-hu.js"></script>
+        <script src="jquery.ui.datepicker-hy.js"></script>
+        <script src="jquery.ui.datepicker-id.js"></script>
+        <script src="jquery.ui.datepicker-is.js"></script>
+        <script src="jquery.ui.datepicker-it.js"></script>
+        <script src="jquery.ui.datepicker-ja.js"></script>
+        <script src="jquery.ui.datepicker-ko.js"></script>
+        <script src="jquery.ui.datepicker-lt.js"></script>
+        <script src="jquery.ui.datepicker-lv.js"></script>
+        <script src="jquery.ui.datepicker-ms.js"></script>
+        <script src="jquery.ui.datepicker-nl.js"></script>
+        <script src="jquery.ui.datepicker-no.js"></script>
+        <script src="jquery.ui.datepicker-pl.js"></script>
+        <script src="jquery.ui.datepicker-pt-BR.js"></script>
+        <script src="jquery.ui.datepicker-ro.js"></script>
+        <script src="jquery.ui.datepicker-ru.js"></script>
+        <script src="jquery.ui.datepicker-sk.js"></script>
+        <script src="jquery.ui.datepicker-sl.js"></script>
+        <script src="jquery.ui.datepicker-sq.js"></script>
+        <script src="jquery.ui.datepicker-sr-SR.js"></script>
+        <script src="jquery.ui.datepicker-sr.js"></script>
+        <script src="jquery.ui.datepicker-sv.js"></script>
+        <script src="jquery.ui.datepicker-ta.js"></script>
+        <script src="jquery.ui.datepicker-th.js"></script>
+        <script src="jquery.ui.datepicker-tr.js"></script>
+        <script src="jquery.ui.datepicker-uk.js"></script>
+        <script src="jquery.ui.datepicker-vi.js"></script>
+        <script src="jquery.ui.datepicker-zh-CN.js"></script>
+        <script src="jquery.ui.datepicker-zh-HK.js"></script>
 	</head>
 	<body>
 	    <textarea id="results" rows="15" cols="40">
         </textarea>
 	</body>
-    <script type="text/javascript">
+    <script>
     //<![CDATA[
     function convertFormat(name, format) {
         format = format


### PR DESCRIPTION
Removed type attribute of javascript <script> form, cos JS it's default scripting language in HTML5.

Flagged few pages from HTML4 --> HTML5