### PR TITLE
Date: Filter am/pm data for "a" date pattern

### DIFF
--- a/src/date/format-properties.js
+++ b/src/date/format-properties.js
@@ -185,9 +185,14 @@ return function( pattern, cldr ) {
 
 			// Period (AM or PM)
 			case "a":
-				properties.dayPeriods = cldr.main(
-					"dates/calendars/gregorian/dayPeriods/format/wide"
-				);
+				properties.dayPeriods = {
+					am: cldr.main(
+						"dates/calendars/gregorian/dayPeriods/format/wide/am"
+					),
+					pm: cldr.main(
+						"dates/calendars/gregorian/dayPeriods/format/wide/pm"
+					)
+				};
 				break;
 
 			// Hour

--- a/src/date/tokenizer-properties.js
+++ b/src/date/tokenizer-properties.js
@@ -1,8 +1,9 @@
 define([
 	"./pattern-re",
 	"../common/create-error/unsupported-feature",
-	"../number/symbol"
-], function( datePatternRe, createErrorUnsupportedFeature, numberSymbol ) {
+	"../number/symbol",
+	"../util/object/filter"
+], function( datePatternRe, createErrorUnsupportedFeature, numberSymbol, objectFilter ) {
 
 /**
  * tokenizerProperties( pattern, cldr )
@@ -126,9 +127,13 @@ return function( pattern, cldr ) {
 
 			// Period (AM or PM)
 			case "a":
-				cldr.main([
+				cldr.main(
 					"dates/calendars/gregorian/dayPeriods/format/wide"
-				]);
+				);
+				properties[ "gregorian/dayPeriods/format/wide" ] = objectFilter(
+					properties[ "gregorian/dayPeriods/format/wide" ],
+					/^am|^pm/
+				);
 				break;
 
 			// Zone

--- a/test/functional/date/date-formatter.js
+++ b/test/functional/date/date-formatter.js
@@ -93,16 +93,8 @@ QUnit.test( "should allow for runtime compilation", function( assert ) {
 			pad2NumberFormatter( runtimeArgs[ 0 ][ 2 ] );
 			assert.deepEqual( runtimeArgs[ 1 ], {
 				"dayPeriods": {
-					"afternoon1": "in the afternoon",
 					"am": "AM",
-					"am-alt-variant": "am",
-					"evening1": "in the evening",
-					"midnight": "midnight",
-					"morning1": "in the morning",
-					"night1": "at night",
-					"noon": "noon",
-					"pm": "PM",
-					"pm-alt-variant": "pm"
+					"pm": "PM"
 				},
 				"pattern": "h:mm:ss a",
 				"timeSeparator": ":"
@@ -165,16 +157,8 @@ QUnit.test( "should allow for runtime compilation", function( assert ) {
 			pad2NumberFormatter( runtimeArgs[ 0 ][ 2 ] );
 			assert.deepEqual( runtimeArgs[ 1 ], {
 				"dayPeriods": {
-					"afternoon1": "in the afternoon",
 					"am": "AM",
-					"am-alt-variant": "am",
-					"evening1": "in the evening",
-					"midnight": "midnight",
-					"morning1": "in the morning",
-					"night1": "at night",
-					"noon": "noon",
-					"pm": "PM",
-					"pm-alt-variant": "pm"
+					"pm": "PM"
 				},
 				"days": {
 					"E": {

--- a/test/unit/date/format-properties.js
+++ b/test/unit/date/format-properties.js
@@ -115,6 +115,7 @@ QUnit.test( "should return days properties for day of week (eee..eeeeee|ccc..ccc
 
 QUnit.test( "should return dayPeriods property for period (a)", function( assert ) {
 	assert.ok( "dayPeriods" in properties( "a", cldr ) );
+	assert.equal( Object.keys(properties( "a", cldr ).dayPeriods).length, 2 );
 });
 
 });

--- a/test/unit/date/parse.js
+++ b/test/unit/date/parse.js
@@ -7,6 +7,8 @@ define([
 	"src/date/tokenizer-properties",
 	"json!cldr-data/main/en/ca-gregorian.json",
 	"json!cldr-data/main/en/numbers.json",
+	"json!cldr-data/main/zh/ca-gregorian.json",
+	"json!cldr-data/main/zh/numbers.json",
 	"json!cldr-data/supplemental/likelySubtags.json",
 	"json!cldr-data/supplemental/timeData.json",
 	"json!cldr-data/supplemental/weekData.json",
@@ -15,9 +17,9 @@ define([
 	"cldr/event",
 	"cldr/supplemental"
 ], function( Cldr, parse, parseProperties, startOf, tokenizer, numberTokenizerProperties,
-	enCaGregorian, enNumbers, likelySubtags, timeData, weekData, util ) {
+	enCaGregorian, enNumbers, zhCaGregorian, zhNumbers, likelySubtags, timeData, weekData, util ) {
 
-var cldr, date1, date2, midnight;
+var cldr, date1, date2, midnight, zh;
 
 function assertParse( assert, stringDate, pattern, cldr, date ) {
 	var tokenizerProperties, tokens;
@@ -50,12 +52,15 @@ function simpleNumberParser( value ) {
 Cldr.load(
 	enCaGregorian,
 	enNumbers,
+	zhCaGregorian,
+	zhNumbers,
 	likelySubtags,
 	timeData,
 	weekData
 );
 
 cldr = new Cldr( "en" );
+zh = new Cldr( "zh" );
 
 midnight = new Date();
 midnight = startOf( midnight, "day" );
@@ -269,6 +274,8 @@ QUnit.test( "should parse period (a)", function( assert ) {
 	date2 = startOf( date2, "hour" );
 	assertParse( assert, "5 AM", "h a", cldr, date1 );
 	assertParse( assert, "5 PM", "h a", cldr, date2 );
+	assertParse( assert, "上午5", "ah", zh, date1 );
+	assertParse( assert, "下午5", "ah", zh, date2 );
 });
 
 /**


### PR DESCRIPTION
CLDR introduced additional dayPeriods (e.g., morning1, afternoon1,
evening1, etc) along with am and pm. The new dayPeriods should be handle
by "b" and "B" date patterns, while the "a" pattern should still handle
am/pm.

For Chinese, the corresponding value for either pm or afternoon1 is
exactly the same, therefore it causes problem on the reverse lookup when
parsing.

This change fixes the above parsing issue by filtering am/pm only in the
parser properties. It also filters it out on formatting as a simple
optimization (to avoid unnecessary properties).

Fixes #509
Closes #508