### PR TITLE
Runtime: Fix unitFormatter with numberFormatter

### DIFF
--- a/src/common/runtime-bind.js
+++ b/src/common/runtime-bind.js
@@ -1,11 +1,12 @@
 define([
 	"./runtime-key",
+	"./runtime-stringify",
 	"../util/function-name"
-], function( runtimeKey, functionName ) {
+], function( runtimeKey, runtimeStringify, functionName ) {
 
 return function( args, cldr, fn, runtimeArgs ) {
 
-	var argsStr = JSON.stringify( args ),
+	var argsStr = runtimeStringify( args ),
 		fnName = functionName( fn ),
 		locale = cldr.locale;
 

--- a/src/common/runtime-key.js
+++ b/src/common/runtime-key.js
@@ -1,10 +1,11 @@
 define([
+	"./runtime-stringify",
 	"../util/string/hash"
-], function( stringHash ) {
+], function( runtimeStringify, stringHash ) {
 
 return function( fnName, locale, args, argsStr ) {
 	var hash;
-	argsStr = argsStr || JSON.stringify( args );
+	argsStr = argsStr || runtimeStringify( args );
 	hash = stringHash( fnName + locale + argsStr );
 	return hash > 0 ? "a" + hash : "b" + Math.abs( hash );
 };

--- a/src/common/runtime-stringify.js
+++ b/src/common/runtime-stringify.js
@@ -1,0 +1,12 @@
+define([], function( ) {
+
+return function( args ) {
+	return JSON.stringify( args, function( key, value ) {
+		if ( typeof value === "function" ) {
+			return value.runtimeKey; // if undefined, the value will be filtered out.
+		}
+		return value;
+	} );
+};
+
+});

--- a/test/compiler/cases/unit.js
+++ b/test/compiler/cases/unit.js
@@ -28,10 +28,9 @@ module.exports = {
 			{ formatter: Globalize.unitFormatter( "hour", {
 				numberFormatter: Globalize.numberFormatter( { minimumIntegerDigits: 1 } )
 			} ), args: [ 3 ] },
-			// TODO: Fails because of https://github.com/globalizejs/globalize/issues/704
-			/* { formatter: Globalize.unitFormatter( "hour", {
+			{ formatter: Globalize.unitFormatter( "hour", {
 				numberFormatter: Globalize.numberFormatter( { minimumIntegerDigits: 2 } )
-			} ), args: [ 3 ] } */
+			} ), args: [ 3 ] },
 
 			{ formatter: en.unitFormatter( "day" ), args: [ 1 ] },
 			{ formatter: en.unitFormatter( "day" ), args: [ 100 ] },

--- a/test/functional/unit/unit-formatter.js
+++ b/test/functional/unit/unit-formatter.js
@@ -129,4 +129,10 @@ QUnit.test( "should allow for runtime compilation", function( assert ) {
 	);
 });
 
+QUnit.test( "should generate different runtime key when using different numberFormatter", function( assert ) {
+	var formatter1 = Globalize.unitFormatter( "hour", { numberFormatter: Globalize.numberFormatter( { minimumIntegerDigits:1 } ) });
+	var formatter2 = Globalize.unitFormatter( "hour", { numberFormatter: Globalize.numberFormatter( { minimumIntegerDigits:2 } ) });
+	assert.notEqual( formatter1.runtimeKey, formatter2.runtimeKey );
+});
+
 });


### PR DESCRIPTION
JSON.stringify omits functions, so the generated runtimeKey
did not depend on the value of the numberFormatter option,
causing different unitFormatters to have an identical runtimeKey.

Fixes #704