### PR TITLE
Test: add tests for compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/.build/
 external/
 node_modules/
 tmp/
+test/compiler/_compiled/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -79,7 +79,7 @@ module.exports = function( grunt ) {
 			},
 			test: {
 				src: [ "test/*.js", "test/functional/**/*.js", "test/unit/**/*.js",
-					"!test/config.js" ],
+					"test/compiler/**/*.js", "!test/config.js", "!test/compiler/_compiled/**" ],
 				options: {
 					jshintrc: "test/.jshintrc"
 				}
@@ -94,8 +94,17 @@ module.exports = function( grunt ) {
 		jscs: {
 			source: [ "src/**/*.js", "!src/build/**" ],
 			grunt: "Gruntfile.js",
-			test: [ "test/*.js", "test/functional/**/*.js", "test/unit/**/*.js" ],
+			test: [ "test/*.js", "test/functional/**/*.js", "test/unit/**/*.js",
+				"test/compiler/**/*.js", "!test/compiler/_compiled/**" ],
 			dist: [ "dist/globalize*.js", "dist/globalize/*.js" ]
+		},
+		mochaTest: {
+			test: {
+				options: {
+					reporter: "spec"
+				},
+				src: [ "test/compiler/*.js" ]
+			}
 		},
 		qunit: {
 			functional: {
@@ -655,6 +664,7 @@ module.exports = function( grunt ) {
 		// TODO fix issues, enable
 		// "jscs:dist",
 		"test:functional",
+		"mochaTest",
 		"uglify",
 		"compare_size",
 		"commitplease"

--- a/package.json
+++ b/package.json
@@ -74,6 +74,8 @@
   },
   "devDependencies": {
     "cldr-data-downloader": "^0.2.5",
+    "glob": "^7.1.1",
+    "globalize-compiler": "^0.3.0-alpha.3",
     "grunt": "0.4.5",
     "grunt-check-dependencies": "0.6.0",
     "grunt-commitplease": "0.0.5",
@@ -88,8 +90,10 @@
     "grunt-contrib-watch": "0.6.1",
     "grunt-git-authors": "^3.1.0",
     "grunt-jscs": "1.8.0",
+    "grunt-mocha-test": "^0.13.2",
     "gzip-js": "0.3.2",
-    "matchdep": "0.3.0"
+    "matchdep": "0.3.0",
+    "mocha": "^3.3.0"
   },
   "commitplease": {
     "nohook": true

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -16,6 +16,10 @@
 	"globals": {
 		"define": false,
 		"require": false,
+		"module": false,
+		"__dirname": false,
+		"describe": false,
+		"it": false,
 		"QUnit": false
 	}
 }

--- a/test/compiler/cases/currency.js
+++ b/test/compiler/cases/currency.js
@@ -1,0 +1,77 @@
+module.exports = {
+	dependencies: function() {
+		var Globalize = require( "../../../dist/node-main.js" );
+
+		Globalize.load(
+			// core
+			require( "../../../external/cldr-data/supplemental/likelySubtags.json" ),
+			// currency
+			require( "../../../external/cldr-data/main/en/currencies.json" ),
+			require( "../../../external/cldr-data/main/de/currencies.json" ),
+			require( "../../../external/cldr-data/main/zh/currencies.json" ),
+			require( "../../../external/cldr-data/supplemental/currencyData.json" ),
+			// number
+			require( "../../../external/cldr-data/main/en/numbers.json" ),
+			require( "../../../external/cldr-data/main/de/numbers.json" ),
+			require( "../../../external/cldr-data/main/zh/numbers.json" ),
+			require( "../../../external/cldr-data/supplemental/numberingSystems.json" ),
+			// plural
+			require( "../../../external/cldr-data/supplemental/plurals.json" ),
+			require( "../../../external/cldr-data/supplemental/ordinals.json" )
+		);
+
+		return Globalize;
+	},
+	cases: function( Globalize ) {
+		var accounting = { style: "accounting" },
+			code = { style: "code" },
+			name = { style: "name" },
+			teslaS = 69900;
+
+		var de, zh;
+
+		de = Globalize( "de" );
+		zh = Globalize( "zh" );
+		Globalize.locale( "en" );
+
+		return [
+			{ formatter: Globalize.currencyFormatter( "USD" ), args: [ teslaS ] },
+			{ formatter: de.currencyFormatter( "USD" ), args: [ teslaS ] },
+			{ formatter: zh.currencyFormatter( "USD" ), args: [ teslaS ] },
+
+			{ formatter: Globalize.currencyFormatter( "USD" ), args: [ -teslaS ] },
+			{ formatter: de.currencyFormatter( "USD" ), args: [ -teslaS ] },
+			{ formatter: zh.currencyFormatter( "USD" ), args: [ -teslaS ] },
+
+			{ formatter: Globalize.currencyFormatter( "USD", code ), args: [ teslaS ] },
+			{ formatter: de.currencyFormatter( "USD", code ), args: [ teslaS ] },
+			{ formatter: zh.currencyFormatter( "USD", code ), args: [ teslaS ] },
+
+			{ formatter: Globalize.currencyFormatter( "USD", name ), args: [ teslaS ] },
+			{ formatter: de.currencyFormatter( "USD", name ), args: [ teslaS ] },
+			{ formatter: zh.currencyFormatter( "USD", name ), args: [ teslaS ] },
+
+			{ formatter: Globalize.currencyFormatter( "USD", accounting ), args: [ -1 ] },
+
+			{ formatter: Globalize.currencyFormatter( "CLF" ), args: [ 12345 ] },
+			{ formatter: Globalize.currencyFormatter( "CLF" ), args: [ 12345.67 ] },
+			{ formatter: Globalize.currencyFormatter( "ZWD" ), args: [ 12345 ] },
+			{ formatter: Globalize.currencyFormatter( "ZWD" ), args: [ 12345.67 ] },
+			{ formatter: Globalize.currencyFormatter( "JPY" ), args: [ 12345.67 ] },
+			{ formatter: Globalize.currencyFormatter( "CLF", code ), args: [ 12345.67 ] },
+			{ formatter: Globalize.currencyFormatter( "CLF", name ), args: [ 12345.67 ] },
+
+			{ formatter: Globalize.currencyFormatter( "CLF", {
+				minimumFractionDigits: 0
+			}), args: [ 12345 ] },
+			{ formatter: Globalize.currencyFormatter( "CLF", {
+				style: "code",
+				minimumFractionDigits: 0
+			}), args: [ 12345 ] },
+			{ formatter: Globalize.currencyFormatter( "CLF", {
+				style: "name",
+				minimumFractionDigits: 0
+			}), args: [ 12345 ] }
+		];
+	}
+};

--- a/test/compiler/cases/date.js
+++ b/test/compiler/cases/date.js
@@ -1,0 +1,36 @@
+module.exports = {
+	dependencies: function() {
+		var Globalize = require( "../../../dist/node-main.js" );
+
+		Globalize.load(
+			// core
+			require( "../../../external/cldr-data/supplemental/likelySubtags.json" ),
+			// date
+			require( "../../../external/cldr-data/main/en/ca-gregorian.json" ),
+			require( "../../../external/cldr-data/main/en/timeZoneNames.json" ),
+			require( "../../../external/cldr-data/supplemental/timeData.json" ),
+			require( "../../../external/cldr-data/supplemental/weekData.json" ),
+			// number
+			require( "../../../external/cldr-data/main/en/numbers.json" ),
+			require( "../../../external/cldr-data/supplemental/numberingSystems.json" )
+		);
+
+		return Globalize;
+	},
+	cases: function( Globalize ) {
+		var date = new Date( 2010, 8, 15, 17, 35, 7, 369 );
+		Globalize.locale( "en" );
+		return [
+			{ formatter: Globalize.dateFormatter({ skeleton: "GyMMMEd" }), args: [ date ] },
+			{ formatter: Globalize.dateFormatter({ skeleton: "dhms" }), args: [ date ] },
+			{ formatter: Globalize.dateFormatter({ skeleton: "GyMMMEdhms" }), args: [ date ] },
+			{ formatter: Globalize.dateFormatter({ skeleton: "Ems" }), args: [ date ] },
+			{ formatter: Globalize.dateFormatter({ skeleton: "yQQQhm" }), args: [ date ] },
+
+			{ formatter: Globalize.dateFormatter({ skeleton: "yMMMMd" }), args: [ date ] },
+			{ formatter: Globalize.dateFormatter({ skeleton: "MMMMd" }), args: [ date ] },
+			{ formatter: Globalize.dateFormatter({ skeleton: "MMMM" }), args: [ date ] },
+			{ formatter: Globalize.dateFormatter({ skeleton: "EEEE" }), args: [ date ] }
+		];
+	}
+};

--- a/test/compiler/cases/message.js
+++ b/test/compiler/cases/message.js
@@ -1,0 +1,28 @@
+module.exports = {
+	dependencies: function() {
+		var Globalize = require( "../../../dist/node-main.js" );
+
+		Globalize.load(
+			// core
+			require( "../../../external/cldr-data/supplemental/likelySubtags.json" )
+		);
+
+		Globalize.loadMessages({
+			en: {
+				greetings: {
+					hello: "Hello, {name}"
+				}
+			}
+		});
+
+		return Globalize;
+	},
+	cases: function( Globalize ) {
+		Globalize.locale( "en" );
+		return [
+			{ formatter: Globalize( "en" ).messageFormatter( "greetings/hello" ), args: [ {
+				name: "Beethoven"
+			} ] }
+		];
+	}
+};

--- a/test/compiler/cases/number.js
+++ b/test/compiler/cases/number.js
@@ -1,0 +1,61 @@
+module.exports = {
+	dependencies: function() {
+		var Globalize = require( "../../../dist/node-main.js" );
+
+		Globalize.load(
+			// core
+			require( "../../../external/cldr-data/supplemental/likelySubtags.json" ),
+			// number
+			require( "../../../external/cldr-data/main/ar/numbers.json" ),
+			require( "../../../external/cldr-data/main/en/numbers.json" ),
+			require( "../../../external/cldr-data/main/es/numbers.json" ),
+			require( "../../../external/cldr-data/main/zh/numbers.json" ),
+			require( "../../../external/cldr-data/supplemental/numberingSystems.json" )
+		);
+
+		return Globalize;
+	},
+	cases: function( Globalize ) {
+		var pi = 3.14159265359;
+		Globalize.locale( "en" );
+		return [
+			{ formatter: Globalize.numberFormatter(), args: [ pi ] },
+			{ formatter: Globalize( "es" ).numberFormatter(), args: [ pi ] },
+			{ formatter: Globalize( "ar" ).numberFormatter(), args: [ pi ] },
+			{ formatter: Globalize( "zh-u-nu-native" ).numberFormatter(), args: [ pi ] },
+			{ formatter: Globalize.numberFormatter(), args: [ 99999999.99 ] },
+
+			{ formatter: Globalize.numberFormatter( {
+				minimumIntegerDigits: 2,
+				minimumFractionDigits: 2,
+				maximumFractionDigits: 2
+			} ), args: [ pi ] },
+			{ formatter: Globalize.numberFormatter( {
+				maximumFractionDigits: 0
+			} ), args: [ pi ] },
+			{ formatter: Globalize.numberFormatter( {
+				minimumFractionDigits: 3
+			} ), args: [ 1.1 ] },
+			{ formatter: Globalize.numberFormatter( {
+				minimumSignificantDigits: 1,
+				maximumSignificantDigits: 3
+			} ), args: [ pi ] },
+			{ formatter: Globalize.numberFormatter( {
+				minimumSignificantDigits: 1,
+				maximumSignificantDigits: 3
+			} ), args: [ 12345 ] },
+			{ formatter: Globalize.numberFormatter( {
+				minimumSignificantDigits: 1,
+				maximumSignificantDigits: 3
+			} ), args: [ 0.00012345 ] },
+			{ formatter: Globalize.numberFormatter( {
+				minimumSignificantDigits: 1,
+				maximumSignificantDigits: 3
+			} ), args: [ 0.00010001 ] },
+			{ formatter: Globalize.numberFormatter( { useGrouping: false } ), args: [ 99999999.99 ] },
+
+			{ formatter: Globalize.numberFormatter( { style: "percent" } ), args: [ pi ] },
+			{ formatter: Globalize( "ar" ).numberFormatter( { style: "percent" } ), args: [ pi ] }
+		];
+	}
+};

--- a/test/compiler/cases/plural.js
+++ b/test/compiler/cases/plural.js
@@ -1,0 +1,102 @@
+module.exports = {
+	dependencies: function() {
+		var Globalize = require( "../../../dist/node-main.js" );
+
+		Globalize.load(
+			// core
+			require( "../../../external/cldr-data/supplemental/likelySubtags.json" ),
+			// plural
+			require( "../../../external/cldr-data/supplemental/plurals.json" ),
+			require( "../../../external/cldr-data/supplemental/ordinals.json" )
+		);
+
+		return Globalize;
+	},
+	cases: function( Globalize ) {
+		Globalize.locale( "en" );
+		return [
+			{ formatter: Globalize.pluralGenerator(), args: [ 0 ] },
+			{ formatter: Globalize.pluralGenerator(), args: [ 0.14 ] },
+
+			{ formatter: Globalize( "en" ).pluralGenerator(), args: [ 0 ] },
+			{ formatter: Globalize( "en" ).pluralGenerator(), args: [ 1 ] },
+			{ formatter: Globalize( "en" ).pluralGenerator(), args: [ 2 ] },
+			{ formatter: Globalize( "en" ).pluralGenerator(), args: [ 1412 ] },
+			{ formatter: Globalize( "en" ).pluralGenerator(), args: [ 0.14 ] },
+			{ formatter: Globalize( "en" ).pluralGenerator(), args: [ 3.14 ] },
+
+			{ formatter: Globalize( "en" ).pluralGenerator( { type: "ordinal" } ), args: [ 0 ] },
+			{ formatter: Globalize( "en" ).pluralGenerator( { type: "ordinal" } ), args: [ 1 ] },
+			{ formatter: Globalize( "en" ).pluralGenerator( { type: "ordinal" } ), args: [ 2 ] },
+			{ formatter: Globalize( "en" ).pluralGenerator( { type: "ordinal" } ), args: [ 3 ] },
+			{ formatter: Globalize( "en" ).pluralGenerator( { type: "ordinal" } ), args: [ 1412 ] },
+			{ formatter: Globalize( "en" ).pluralGenerator( { type: "ordinal" } ), args: [ 0.14 ] },
+			{ formatter: Globalize( "en" ).pluralGenerator( { type: "ordinal" } ), args: [ 3.14 ] },
+
+			{ formatter: Globalize( "ar" ).pluralGenerator(), args: [ 0 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator(), args: [ 1 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator(), args: [ 2 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator(), args: [ 3 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator(), args: [ 6 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator(), args: [ 9 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator(), args: [ 10 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator(), args: [ 11 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator(), args: [ 15 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator(), args: [ 21 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator(), args: [ 70 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator(), args: [ 99 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator(), args: [ 100 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator(), args: [ 101 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator(), args: [ 102 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator(), args: [ 103 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator(), args: [ 111 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator(), args: [ 199 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator(), args: [ 3.14 ] },
+
+			{ formatter: Globalize( "ar" ).pluralGenerator( { type: "ordinal" } ), args: [ 0 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator( { type: "ordinal" } ), args: [ 1 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator( { type: "ordinal" } ), args: [ 2 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator( { type: "ordinal" } ), args: [ 3 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator( { type: "ordinal" } ), args: [ 9 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator( { type: "ordinal" } ), args: [ 10 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator( { type: "ordinal" } ), args: [ 11 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator( { type: "ordinal" } ), args: [ 99 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator( { type: "ordinal" } ), args: [ 100 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator( { type: "ordinal" } ), args: [ 101 ] },
+			{ formatter: Globalize( "ar" ).pluralGenerator( { type: "ordinal" } ), args: [ 3.14 ] },
+
+
+			{ formatter: Globalize( "ja" ).pluralGenerator(), args: [ 0 ] },
+			{ formatter: Globalize( "ja" ).pluralGenerator(), args: [ 1 ] },
+			{ formatter: Globalize( "ja" ).pluralGenerator(), args: [ 2 ] },
+			{ formatter: Globalize( "ja" ).pluralGenerator(), args: [ 3.14 ] },
+
+			{ formatter: Globalize( "pt" ).pluralGenerator(), args: [ 0 ] },
+			{ formatter: Globalize( "pt" ).pluralGenerator(), args: [ 1 ] },
+			{ formatter: Globalize( "pt" ).pluralGenerator(), args: [ 2 ] },
+			{ formatter: Globalize( "pt" ).pluralGenerator(), args: [ 0.1 ] },
+			{ formatter: Globalize( "pt" ).pluralGenerator(), args: [ 3.14 ] },
+
+			{ formatter: Globalize( "ru" ).pluralGenerator(), args: [ 0 ] },
+			{ formatter: Globalize( "ru" ).pluralGenerator(), args: [ 1 ] },
+			{ formatter: Globalize( "ru" ).pluralGenerator(), args: [ 2 ] },
+			{ formatter: Globalize( "ru" ).pluralGenerator(), args: [ 3 ] },
+			{ formatter: Globalize( "ru" ).pluralGenerator(), args: [ 4 ] },
+			{ formatter: Globalize( "ru" ).pluralGenerator(), args: [ 5 ] },
+			{ formatter: Globalize( "ru" ).pluralGenerator(), args: [ 6 ] },
+			{ formatter: Globalize( "ru" ).pluralGenerator(), args: [ 9 ] },
+			{ formatter: Globalize( "ru" ).pluralGenerator(), args: [ 11 ] },
+			{ formatter: Globalize( "ru" ).pluralGenerator(), args: [ 12 ] },
+			{ formatter: Globalize( "ru" ).pluralGenerator(), args: [ 19 ] },
+			{ formatter: Globalize( "ru" ).pluralGenerator(), args: [ 21 ] },
+			{ formatter: Globalize( "ru" ).pluralGenerator(), args: [ 22 ] },
+			{ formatter: Globalize( "ru" ).pluralGenerator(), args: [ 29 ] },
+			{ formatter: Globalize( "ru" ).pluralGenerator(), args: [ 3.14 ] },
+
+			{ formatter: Globalize( "zh" ).pluralGenerator(), args: [ 0 ] },
+			{ formatter: Globalize( "zh" ).pluralGenerator(), args: [ 1 ] },
+			{ formatter: Globalize( "zh" ).pluralGenerator(), args: [ 2 ] },
+			{ formatter: Globalize( "zh" ).pluralGenerator(), args: [ 3.14 ] }
+		];
+	}
+};

--- a/test/compiler/cases/relative-time.js
+++ b/test/compiler/cases/relative-time.js
@@ -1,0 +1,36 @@
+module.exports = {
+	dependencies: function() {
+		var Globalize = require( "../../../dist/node-main.js" );
+
+		Globalize.load(
+			// core
+			require( "../../../external/cldr-data/supplemental/likelySubtags.json" ),
+			// relative time
+			require( "../../../external/cldr-data/main/en/dateFields.json" ),
+			require( "../../../external/cldr-data/main/de/dateFields.json" ),
+			// number
+			require( "../../../external/cldr-data/main/en/numbers.json" ),
+			require( "../../../external/cldr-data/main/de/numbers.json" ),
+			require( "../../../external/cldr-data/supplemental/numberingSystems.json" ),
+			// plural
+			require( "../../../external/cldr-data/supplemental/plurals.json" ),
+			require( "../../../external/cldr-data/supplemental/ordinals.json" )
+		);
+
+		return Globalize;
+	},
+	cases: function( Globalize ) {
+		var de, en;
+		Globalize.locale( "en" );
+		de = new Globalize( "de" );
+		en = new Globalize( "en" );
+
+		return [
+			{ formatter: en.relativeTimeFormatter( "week" ), args: [ -2 ] },
+			{ formatter: en.relativeTimeFormatter( "year" ), args: [ 3 ] },
+			{ formatter: en.relativeTimeFormatter( "day" ), args: [ 0 ] },
+			{ formatter: en.relativeTimeFormatter( "day" ), args: [ 1 ] },
+			{ formatter: de.relativeTimeFormatter( "day" ), args: [ 2 ] }
+		];
+	}
+};

--- a/test/compiler/cases/unit.js
+++ b/test/compiler/cases/unit.js
@@ -1,0 +1,66 @@
+module.exports = {
+	dependencies: function() {
+		var Globalize = require( "../../../dist/node-main.js" );
+
+		Globalize.load(
+			// core
+			require( "../../../external/cldr-data/supplemental/likelySubtags.json" ),
+			// unit
+			require( "../../../external/cldr-data/main/en/units.json" ),
+			require( "../../../external/cldr-data/main/de/units.json" ),
+			// number
+			require( "../../../external/cldr-data/main/en/numbers.json" ),
+			require( "../../../external/cldr-data/main/de/numbers.json" ),
+			require( "../../../external/cldr-data/supplemental/numberingSystems.json" ),
+			// plural
+			require( "../../../external/cldr-data/supplemental/plurals.json" ),
+			require( "../../../external/cldr-data/supplemental/ordinals.json" )
+		);
+
+		return Globalize;
+	},
+	cases: function( Globalize ) {
+		var de, en;
+		Globalize.locale( "en" );
+		de = new Globalize( "de" );
+		en = new Globalize( "en" );
+		return [
+			{ formatter: Globalize.unitFormatter( "hour", {
+				numberFormatter: Globalize.numberFormatter( { minimumIntegerDigits: 1 } )
+			} ), args: [ 3 ] },
+			// TODO: Fails because of https://github.com/globalizejs/globalize/issues/704
+			/* { formatter: Globalize.unitFormatter( "hour", {
+				numberFormatter: Globalize.numberFormatter( { minimumIntegerDigits: 2 } )
+			} ), args: [ 3 ] } */
+
+			{ formatter: en.unitFormatter( "day" ), args: [ 1 ] },
+			{ formatter: en.unitFormatter( "day" ), args: [ 100 ] },
+
+			{ formatter: de.unitFormatter( "day" ), args: [ 1 ] },
+			{ formatter: de.unitFormatter( "day" ), args: [ 100 ] },
+
+			{ formatter: en.unitFormatter( "day", { form: "long" } ), args: [ 1 ] },
+			{ formatter: en.unitFormatter( "day", { form: "long" } ), args: [ 100 ] },
+
+			{ formatter: de.unitFormatter( "day", { form: "long" } ), args: [ 1 ] },
+			{ formatter: de.unitFormatter( "day", { form: "long" } ), args: [ 100 ] },
+
+			{ formatter: en.unitFormatter( "second", { form: "short" } ), args: [ 1 ] },
+			{ formatter: en.unitFormatter( "second", { form: "short" } ), args: [ 100 ] },
+
+			{ formatter: en.unitFormatter( "second", { form: "narrow" } ), args: [ 1 ] },
+			{ formatter: en.unitFormatter( "second", { form: "narrow" } ), args: [ 100 ] },
+
+			{ formatter: en.unitFormatter( "mile-per-hour", { form: "narrow" } ), args: [ 5 ] },
+
+			{ formatter: en.unitFormatter( "mile-per-second", { form: "narrow" } ), args: [ 5 ] },
+
+			{ formatter: en.unitFormatter( "mile/hour", { form: "narrow" } ), args: [ 5 ] },
+
+			{ formatter: en.unitFormatter( "mile/second", { form: "narrow" } ), args: [ 5 ] },
+
+			{ formatter: en.unitFormatter( "mile/hour", { form: "short" } ), args: [ 55000 ] },
+			{ formatter: de.unitFormatter( "mile/hour", { form: "short" } ), args: [ 55000 ] }
+		];
+	}
+};

--- a/test/compiler/test.js
+++ b/test/compiler/test.js
@@ -1,0 +1,74 @@
+var globalizeCompiler = require( "globalize-compiler" );
+var fs = require( "fs" );
+var path = require( "path" );
+var childProcess = require( "child_process" );
+var assert = require( "assert" );
+var glob = require( "glob" );
+
+describe( "compiled", function() {
+	if ( !fs.existsSync( path.join( __dirname, "_compiled" ) ) ) {
+		fs.mkdirSync( path.join( __dirname, "_compiled" ) );
+	}
+	var files = glob.sync( "cases/*.js", {
+		cwd: __dirname
+	} );
+	files.forEach( function(file) {
+		var name = path.basename( file, ".js" );
+		describe( name, function() {
+			it( "should return identical data", function( done ) {
+				var test = require( "./" + file );
+				var expectedOutput = "";
+				var formatters = [];
+				var testCases = test.cases( test.dependencies() );
+				testCases.forEach( function( testCase ) {
+					formatters.push( testCase.formatter );
+					expectedOutput += testCase.formatter.apply( null, testCase.args ) + "\n";
+				});
+				var out = globalizeCompiler.compile( formatters, {
+					template: function( data ) {
+						var deps = "var Globalize = " +
+							data.dependencies.map( function( dependency ) {
+								return "require( \"../../../dist/" + dependency + "\" )";
+							} ).join( ";\n" );
+						return [
+							deps,
+							"",
+							data.code,
+							"",
+							"module.exports = Globalize;"
+						].join( "\n" );
+					}
+				} );
+				fs.writeFileSync( path.join( __dirname, "_compiled/" + name + ".compiled.js" ), out );
+				fs.writeFileSync( path.join( __dirname, "_compiled/" + name + ".test.js" ), [
+					"var test = require( \"../" + file + "\" );",
+					"var Globalize = require( \"../_compiled/" + name + ".compiled.js\" );",
+					"testCases = test.cases( Globalize );",
+					"testCases.forEach( function( testCase ) {",
+						"console.log( testCase.formatter.apply( null, testCase.args ) );",
+					"});"
+				].join("\n") );
+				var childOutput = "";
+				var child = childProcess.fork(
+					path.join( __dirname, "_compiled/" + name + ".test.js" ),
+					{ silent: true }
+				);
+				child.on( "error", function( err ) {
+					done( err );
+				} );
+				child.on( "exit", function( exit ) {
+					if ( exit !== 0 ) {
+						done( new Error( "exited with non-zero" ) );
+					}
+				} );
+				child.stdout.on( "data", function( chunk ) {
+					childOutput += chunk.toString();
+				} );
+				child.stdout.on( "end", function() {
+					assert.equal( childOutput, expectedOutput );
+					done();
+				} );
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
globalize-compiler complains about missing peer dependencies. One is globalize, the other two are cldr-data and iana-tz-data.

Globalize is obviously available, cldr-data is also available from bower. So it still works.

iana-tz-data was recently added to globalize-compiler, but it's not in globalize.js's master, only in the 1.3.0-alpha.3 tag. I think you might have forgotten to push to master.