### PR TITLE
Date: Fix dateFormatter runtime

### DIFF
--- a/src/common/runtime-bind.js
+++ b/src/common/runtime-bind.js
@@ -9,7 +9,7 @@ return function( args, cldr, fn, runtimeArgs ) {
 		fnName = functionName( fn ),
 		locale = cldr.locale;
 
-	// If name of the function is not available, this is most likely due uglification,
+	// If name of the function is not available, this is most likely due to uglification,
 	// which most likely means we are in production, and runtimeBind here is not necessary.
 	if ( !fnName ) {
 		return fn;

--- a/src/date-runtime.js
+++ b/src/date-runtime.js
@@ -5,32 +5,29 @@ define([
 	"./common/validate/parameter-type/string",
 	"./core-runtime",
 	"./date/format",
+	"./date/formatter-fn",
 	"./date/parse",
 	"./date/parser-fn",
-	"./date/to-parts-formatter-fn",
 	"./date/tokenizer",
+	"./date/to-parts-formatter-fn",
 
 	"./number-runtime"
 ], function( runtimeKey, validateParameterPresence, validateParameterTypeDate,
-	validateParameterTypeString, Globalize, dateFormat, dateParse, dateParserFn,
+	validateParameterTypeString, Globalize, dateFormat, dateFormatterFn, dateParse, dateParserFn,
 	dateToPartsFormatterFn, dateTokenizer ) {
 
 Globalize._dateFormat = dateFormat;
+Globalize._dateFormatterFn = dateFormatterFn;
 Globalize._dateParser = dateParse;
 Globalize._dateParserFn = dateParserFn;
-Globalize._dateToPartsFormatterFn = dateToPartsFormatterFn;
 Globalize._dateTokenizer = dateTokenizer;
+Globalize._dateToPartsFormatterFn = dateToPartsFormatterFn;
 Globalize._validateParameterTypeDate = validateParameterTypeDate;
 
 Globalize.dateFormatter =
 Globalize.prototype.dateFormatter = function( options ) {
-	var formatterFn = this.dateToPartsFormatter( options );
-	return function() {
-		var parts = formatterFn.apply( this, arguments );
-		return parts.map( function( part ) {
-			return part.value;
-		}).join( "" );
-	};
+	options = options || { skeleton: "yMd" };
+	return Globalize[ runtimeKey( "dateFormatter", this._locale, [ options ] ) ];
 };
 
 Globalize.dateToPartsFormatter =

--- a/src/date.js
+++ b/src/date.js
@@ -10,19 +10,21 @@ define([
 	"./common/validate/parameter-type/string",
 	"./core",
 	"./date/expand-pattern",
-	"./date/to-parts-formatter-fn",
 	"./date/format-properties",
-	"./date/parser-fn",
+	"./date/formatter-fn",
 	"./date/parse-properties",
+	"./date/parser-fn",
 	"./date/tokenizer-properties",
+	"./date/to-parts-formatter-fn",
 
 	"cldr/event",
 	"cldr/supplemental",
 	"./number"
 ], function( Cldr, runtimeBind, validate, validateCldr, validateDefaultLocale,
 	validateParameterPresence, validateParameterTypeDate, validateParameterTypePlainObject,
-	validateParameterTypeString, Globalize, dateExpandPattern, dateToPartsFormatterFn,
-	dateFormatProperties, dateParserFn, dateParseProperties, dateTokenizerProperties ) {
+	validateParameterTypeString, Globalize, dateExpandPattern, dateFormatProperties,
+	dateFormatterFn, dateParseProperties, dateParserFn, dateTokenizerProperties,
+	dateToPartsFormatterFn ) {
 
 function validateRequiredCldr( path, value ) {
 	validateCldr( path, value, {
@@ -77,13 +79,18 @@ function validateOptionsSkeleton( pattern, skeleton ) {
  */
 Globalize.dateFormatter =
 Globalize.prototype.dateFormatter = function( options ) {
-	var formatterFn = this.dateToPartsFormatter( options );
-	return function() {
-		var parts = formatterFn.apply( this, arguments );
-		return parts.map( function( part ) {
-			return part.value;
-		}).join( "" );
-	};
+	var args, dateToPartsFormatter, returnFn;
+
+	validateParameterTypePlainObject( options, "options" );
+
+	options = options || { skeleton: "yMd" };
+	args = [ options ];
+
+	dateToPartsFormatter = this.dateToPartsFormatter( options );
+	returnFn = dateFormatterFn( dateToPartsFormatter );
+	runtimeBind( args, this.cldr, returnFn, [ dateToPartsFormatter ] );
+
+	return returnFn;
 };
 
 /**

--- a/src/date/formatter-fn.js
+++ b/src/date/formatter-fn.js
@@ -1,0 +1,11 @@
+define(function() {
+
+return function( dateToPartsFormatter ) {
+	return function dateFormatter( value ) {
+		return dateToPartsFormatter( value ).map( function( part ) {
+			return part.value;
+		}).join( "" );
+	};
+};
+
+});


### PR DESCRIPTION
When dateToPartsFormatter was added, dateFormatter became an alias to
it. Although globalize-compiler can handle it by using
`.compileExtracts()`, it doesn't by using `.compile()` and passing
`formattersAndParsers` argument. This update fixed that.

Amends e4234a7
Ref #678
Ref #697
Ref #700