### PR TITLE
Date parser: Assert numeric token.value is not NaN

### DIFF
--- a/src/date/tokenizer.js
+++ b/src/date/tokenizer.js
@@ -493,6 +493,10 @@ return function( value, numberParser, properties ) {
 			return false;
 		}
 
+		if ( numeric && isNaN( token.value ) ) {
+			return false;
+		}
+
 		tokens.push( token );
 		return true;
 	});

--- a/test/unit/date/parse.js
+++ b/test/unit/date/parse.js
@@ -409,6 +409,9 @@ QUnit.test( "should parse composite of date fields", function( assert ) {
 	// Loose matching: ignore control characters.
 	date1 = new Date( 2010, 8, 15 );
 	assert.dateParse( "15/9/2010", "d\u200f/M\u200f/y", cldr, date1 );
+
+	// Test #696 - Mix of numbering systems.
+	assert.dateParse( "15/٧/2010", "d/M/y", cldr, null );
 });
 
 /**

--- a/test/unit/date/tokenizer.js
+++ b/test/unit/date/tokenizer.js
@@ -342,6 +342,9 @@ QUnit.test( "should tokenize day (d) with no padding", function( assert ) {
 		lexeme: "2",
 		value: 2
 	}] );
+
+	// Test #696 - Mix of numbering systems.
+	assert.dateTokenizer( "٧", "d", cldr, [] );
 });
 
 QUnit.test( "should tokenize day (dd) with padding", function( assert ) {


### PR DESCRIPTION
Fixes #696