### PR TITLE
Package.json: Bump ZonedDateTime to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "matchdep": "0.3.0",
     "mocha": "^3.3.0",
     "semver": "^5.3.0",
-    "zoned-date-time": "0.0.4"
+    "zoned-date-time": "1.0.0"
   },
   "commitplease": {
     "nohook": true

--- a/src/date/parse.js
+++ b/src/date/parse.js
@@ -293,9 +293,7 @@ return function( value, tokens, properties ) {
 
 	// Get date back from globalize date.
 	if ( date instanceof ZonedDateTime ) {
-
-		// TODO can we improve this? E.g., toDate()
-		date = new Date( date.getTime() );
+		date = date.toDate();
 	}
 
 	return date;


### PR DESCRIPTION
- Include a fix for phantomjs
- Use ZonedDateTime.prototype.toDate()

Fixes #747