### PR TITLE
Runtime: add runtime version, set it to 1

### DIFF
--- a/src/common/runtime-bind.js
+++ b/src/common/runtime-bind.js
@@ -1,7 +1,8 @@
 define([
 	"./runtime-key",
-	"../util/function-name"
-], function( runtimeKey, functionName ) {
+	"../util/function-name",
+	"./runtime-version"
+], function( runtimeKey, functionName, runtimeVersion ) {
 
 return function( args, cldr, fn, runtimeArgs ) {
 
@@ -22,6 +23,8 @@ return function( args, cldr, fn, runtimeArgs ) {
 	};
 
 	fn.runtimeArgs = runtimeArgs;
+
+	fn.runtimeVersion = runtimeVersion;
 
 	return fn;
 };

--- a/src/common/runtime-version.js
+++ b/src/common/runtime-version.js
@@ -1,0 +1,5 @@
+define([], function( ) {
+
+return 1;
+
+});

--- a/src/core-runtime.js
+++ b/src/core-runtime.js
@@ -2,12 +2,13 @@ define([
 	"./common/create-error",
 	"./common/format-message",
 	"./common/runtime-key",
+	"./common/runtime-version",
 	"./common/validate/parameter-presence",
 	"./common/validate/parameter-type",
 	"./common/validate/parameter-type/string",
 	"./util/regexp/escape",
 	"./util/string/pad"
-], function( createError, formatMessage, runtimeKey, validateParameterPresence,
+], function( createError, formatMessage, runtimeKey, runtimeVersion, validateParameterPresence,
 	validateParameterType, validateParameterTypeString, regexpEscape, stringPad ) {
 
 function Globalize( locale ) {
@@ -29,6 +30,8 @@ Globalize.locale = function( locale ) {
 	}
 	return this._locale;
 };
+
+Globalize.runtimeVersion = runtimeVersion;
 
 Globalize._createError = createError;
 Globalize._formatMessage = formatMessage;

--- a/src/core.js
+++ b/src/core.js
@@ -3,6 +3,7 @@ define([
 	"./common/create-error",
 	"./common/format-message",
 	"./common/runtime-bind",
+	"./common/runtime-version",
 	"./common/validate",
 	"./common/validate/cldr",
 	"./common/validate/default-locale",
@@ -19,7 +20,7 @@ define([
 	"./util/string/pad",
 
 	"cldr/event"
-], function( Cldr, createError, formatMessage, runtimeBind, validate, validateCldr,
+], function( Cldr, createError, formatMessage, runtimeBind, runtimeVersion, validate, validateCldr,
 	validateDefaultLocale, validateParameterPresence, validateParameterRange, validateParameterType,
 	validateParameterTypeLocale, validateParameterTypePlainObject, alwaysArray, alwaysCldr,
 	isPlainObject, objectExtend, regexpEscape, stringPad ) {
@@ -85,6 +86,8 @@ Globalize.locale = function( locale ) {
 	}
 	return this.cldr;
 };
+
+Globalize.runtimeVersion = runtimeVersion;
 
 /**
  * Optimization to avoid duplicating some internal functions across modules.


### PR DESCRIPTION
Refs #720 

The corresponding compiler PR is https://github.com/globalizejs/globalize-compiler/pull/34

I did it this way so that if you're directly using compiler.compile, it'll work without changes.
The compiler will also work without the change in globalize.js.