### PR TITLE
Number: Fix fraction digit options for patterns with no fraction digits

### DIFF
--- a/src/number/pattern-properties.js
+++ b/src/number/pattern-properties.js
@@ -60,6 +60,9 @@ return function( pattern ) {
 			// Maximum fraction digits
 			// 1: ignore decimal character
 			maximumFractionDigits = fractionPattern.length - 1 /* 1 */;
+		} else {
+			minimumFractionDigits = 0;
+			maximumFractionDigits = 0;
 		}
 
 		// Minimum integer digits

--- a/test/functional/currency/currency-formatter.js
+++ b/test/functional/currency/currency-formatter.js
@@ -127,6 +127,14 @@ QUnit.test( "should return a currency formatter, overriden by user options",
 		minimumFractionDigits: 0
 	})( 12345 ), "CLF 12,345" );
 
+	assert.equal( Globalize.currencyFormatter( "JPY", {
+		maximumFractionDigits: 0
+	})( 12345 ), "¥12,345" );
+
+	assert.equal( Globalize.currencyFormatter( "JPY", {
+		minimumFractionDigits: 2
+	})( 12345 ), "¥12,345.00" );
+
 	assert.equal( Globalize.currencyFormatter( "CLF", {
 		style: "code",
 		minimumFractionDigits: 0

--- a/test/unit/number/pattern-properties.js
+++ b/test/unit/number/pattern-properties.js
@@ -32,13 +32,13 @@ QUnit.test( "should return minimumIntegerDigits", function( assert ) {
 });
 
 QUnit.test( "should return minimumFractionDigits", function( assert ) {
-	assert.equal( properties( "0", en )[ 3 ], undefined );
+	assert.equal( properties( "0", en )[ 3 ], 0 );
 	assert.equal( properties( "0.##", en )[ 3 ], 0 );
 	assert.equal( properties( "0.0#", en )[ 3 ], 1 );
 });
 
 QUnit.test( "should return maximumFractionDigits", function( assert ) {
-	assert.equal( properties( "0", en )[ 4 ], undefined );
+	assert.equal( properties( "0", en )[ 4 ], 0 );
 	assert.equal( properties( "0.##", en )[ 4 ], 2 );
 	assert.equal( properties( "0.0#", en )[ 4 ], 2 );
 });


### PR DESCRIPTION
This fixes a bug when setting the `minimumFractionDigits` or `maximumFractionDigits` options for number patterns that contain no fraction digits, such as for JPY and other currencies without fraction digits, which currently results in the error E_PAR_OUT_OF_RANGE. The primary use case is for products that don't use fraction digits in their prices for any currency (e.g. $99, £59, 99 €, ￥12,000) and consistently set `maximumFractionDigits: 0`.

Currencies affected: ADP, AFN, ALL, AMD, BIF, BYR, CLP, COP, DJF, ESP, GNF, GYD, IDR, IQD, IRR, ISK, ITL, JPY, KMF, KPW, KRW, LAK, LBP, LUF, MGA, MGF, MMK, MNT, MRO, MUR, PKR, PYG, RSD, RWF, SLL, SOS, STD, SYP, TMM, TRL, TZS, UGX, UZS, UYI, VND, VUV, XAF, XOF, XPF, YER, ZMK, ZWD

Fixes #472
Fixes #565