### PR TITLE
Date: Add fractional seconds support in formatters

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -279,10 +279,8 @@ module.exports = function( grunt ) {
 						.replace( /define\(\[[^\]]+\]\)[\W\n]+$/, "" ); /* 3 */
 
 					// Type b (not as simple as a single return)
-					if ( [ "util/globalize-date" ].indexOf( id ) !== -1 ) {
-						contents = "var " + name[ 0 ].toUpperCase() +
-							name.slice( 1 ) + " = (function() {" +
-							contents + "}());";
+					if ( [ "expand-pattern/augment-format" ].indexOf( id ) !== -1 ) {
+						contents = "var " + name + " = (function() {" + contents + "}());";
 
 					// Type a (single return)
 					} else if ( ( /\// ).test( id ) ) {

--- a/src/date/expand-pattern/augment-format.js
+++ b/src/date/expand-pattern/augment-format.js
@@ -4,7 +4,7 @@ define([
 	"../../util/string/repeat"
 ], function( dateExpandPatternNormalizePatternType, datePatternRe, stringRepeat ) {
 
-function expandBestMatchFormat(skeletonWithoutFractionalSeconds, bestMatchFormat) {
+function expandBestMatchFormat( skeletonWithoutFractionalSeconds, bestMatchFormat ) {
 	var i, j, bestMatchFormatParts, matchedType, matchedLength, requestedType,
 		requestedLength, requestedSkeletonParts,
 
@@ -33,22 +33,22 @@ function expandBestMatchFormat(skeletonWithoutFractionalSeconds, bestMatchFormat
 
 // See: http://www.unicode.org/reports/tr35/tr35-dates.html#Matching_Skeletons
 return function( requestedSkeleton, bestMatchFormat, decimalSeparator ) {
-	var countOfFractionalSeconds, fractionalSecondMatch,lastSecondIdx,
-		skeletonWithoutFractionalSeconds,
+	var countOfFractionalSeconds, fractionalSecondMatch, lastSecondIdx,
+		skeletonWithoutFractionalSeconds;
 
 	fractionalSecondMatch = requestedSkeleton.match( /S/g );
 	countOfFractionalSeconds = fractionalSecondMatch ? fractionalSecondMatch.length : 0;
 	skeletonWithoutFractionalSeconds = requestedSkeleton.replace( /S/g, "" );
 
-	bestMatchFormat = expandBestMatchFormat(skeletonWithoutFractionalSeconds, bestMatchFormat);
+	bestMatchFormat = expandBestMatchFormat( skeletonWithoutFractionalSeconds, bestMatchFormat );
 
-	lastSecondIdx = bestMatchFormat.lastIndexOf("s");
-	if (lastSecondIdx !== -1 && countOfFractionalSeconds !== 0 ) {
+	lastSecondIdx = bestMatchFormat.lastIndexOf( "s" );
+	if ( lastSecondIdx !== -1 && countOfFractionalSeconds !== 0 ) {
 		bestMatchFormat =
-			bestMatchFormat.slice(0, lastSecondIdx + 1) +
+			bestMatchFormat.slice( 0, lastSecondIdx + 1 ) +
 			decimalSeparator +
 			stringRepeat( "S", countOfFractionalSeconds ) +
-			bestMatchFormat.slice(lastSecondIdx + 1);
+			bestMatchFormat.slice( lastSecondIdx + 1 );
 	}
 	return bestMatchFormat;
 };

--- a/src/date/expand-pattern/get-best-match-pattern.js
+++ b/src/date/expand-pattern/get-best-match-pattern.js
@@ -1,10 +1,11 @@
 define([
 	"./augment-format",
-	"./compare-formats"
-], function( dateExpandPatternAugmentFormat, dateExpandPatternCompareFormats ) {
+	"./compare-formats",
+	"../../number/symbol"
+], function( dateExpandPatternAugmentFormat, dateExpandPatternCompareFormats, numberSymbol ) {
 
 return function( cldr, askedSkeleton ) {
-	var availableFormats, pattern, ratedFormats, skeleton,
+	var availableFormats, decimalSeparator, pattern, ratedFormats, skeleton,
 		path = "dates/calendars/gregorian/dateTimeFormats/availableFormats",
 
 		// Using easier to read variables.
@@ -34,7 +35,8 @@ return function( cldr, askedSkeleton ) {
 			});
 
 		if ( ratedFormats.length ) {
-			pattern = augmentFormat( askedSkeleton, ratedFormats[0].pattern );
+			decimalSeparator = numberSymbol( "decimal", cldr );
+			pattern = augmentFormat( askedSkeleton, ratedFormats[0].pattern, decimalSeparator );
 		}
 	}
 

--- a/test/compiler/cases/date.js
+++ b/test/compiler/cases/date.js
@@ -29,7 +29,7 @@ module.exports = {
 
 			{ formatter: Globalize.dateFormatter({ skeleton: "GyMMMEd" }), args: [ date ] },
 			{ formatter: Globalize.dateFormatter({ skeleton: "dhms" }), args: [ date ] },
-			{ formatter: Globalize.dateFormatter({ skeleton: "GyMMMEdhms" }), args: [ date ] },
+			{ formatter: Globalize.dateFormatter({ skeleton: "GyMMMEdhmsSSS" }), args: [ date ] },
 			{ formatter: Globalize.dateFormatter({ skeleton: "Ems" }), args: [ date ] },
 			{ formatter: Globalize.dateFormatter({ skeleton: "yQQQhm" }), args: [ date ] },
 

--- a/test/compiler/cases/date.js
+++ b/test/compiler/cases/date.js
@@ -29,6 +29,7 @@ module.exports = {
 
 			{ formatter: Globalize.dateFormatter({ skeleton: "GyMMMEd" }), args: [ date ] },
 			{ formatter: Globalize.dateFormatter({ skeleton: "dhms" }), args: [ date ] },
+			{ formatter: Globalize.dateFormatter({ skeleton: "GyMMMEdhms" }), args: [ date ] },
 			{ formatter: Globalize.dateFormatter({ skeleton: "GyMMMEdhmsSSS" }), args: [ date ] },
 			{ formatter: Globalize.dateFormatter({ skeleton: "Ems" }), args: [ date ] },
 			{ formatter: Globalize.dateFormatter({ skeleton: "yQQQhm" }), args: [ date ] },

--- a/test/functional/date/date-formatter.js
+++ b/test/functional/date/date-formatter.js
@@ -88,7 +88,7 @@ QUnit.test( "should return a formatter", function( assert ) {
 
 	assert.equal( Globalize.dateFormatter({ skeleton: "GyMMMEd" })( date ), "Wed, Sep 15, 2010 AD" );
 	assert.equal( Globalize.dateFormatter({ skeleton: "dhms" })( date ), "15, 5:35:07 PM" );
-	assert.equal( Globalize.dateFormatter({ skeleton: "GyMMMEdhms" })( date ), "Wed, Sep 15, 2010 AD, 5:35:07 PM" );
+	assert.equal( Globalize.dateFormatter({ skeleton: "GyMMMEdhmsSSS" })( date ), "Wed, Sep 15, 2010 AD, 5:35:07.369 PM" );
 	assert.equal( Globalize.dateFormatter({ skeleton: "Ems" })( date ), "Wed, 35:07" );
 	assert.equal( Globalize.dateFormatter({ skeleton: "yQQQhm" })( date ), "Q3 2010, 5:35 PM" );
 });

--- a/test/functional/date/date-formatter.js
+++ b/test/functional/date/date-formatter.js
@@ -88,6 +88,7 @@ QUnit.test( "should return a formatter", function( assert ) {
 
 	assert.equal( Globalize.dateFormatter({ skeleton: "GyMMMEd" })( date ), "Wed, Sep 15, 2010 AD" );
 	assert.equal( Globalize.dateFormatter({ skeleton: "dhms" })( date ), "15, 5:35:07 PM" );
+	assert.equal( Globalize.dateFormatter({ skeleton: "GyMMMEdhms" })( date ), "Wed, Sep 15, 2010 AD, 5:35:07 PM" );
 	assert.equal( Globalize.dateFormatter({ skeleton: "GyMMMEdhmsSSS" })( date ), "Wed, Sep 15, 2010 AD, 5:35:07.369 PM" );
 	assert.equal( Globalize.dateFormatter({ skeleton: "Ems" })( date ), "Wed, 35:07" );
 	assert.equal( Globalize.dateFormatter({ skeleton: "yQQQhm" })( date ), "Q3 2010, 5:35 PM" );

--- a/test/functional/date/parse-date.js
+++ b/test/functional/date/parse-date.js
@@ -141,6 +141,13 @@ QUnit.test( "should parse skeleton", function( assert ) {
 	date.setHours( 17 );
 	date.setMinutes( 35 );
 	date.setSeconds( 7 );
+	date = startOf( date, "second" );
+	assertParseDate( assert, "Wed 5:35:07 PM", { skeleton: "Ehms" }, date );
+
+	date = new Date();
+	date.setHours( 17 );
+	date.setMinutes( 35 );
+	date.setSeconds( 7 );
 	date.setMilliseconds(734);
 	assertParseDate( assert, "Wed 5:35:07.734 PM", { skeleton: "EhmsSSS" }, date );
 

--- a/test/functional/date/parse-date.js
+++ b/test/functional/date/parse-date.js
@@ -141,8 +141,8 @@ QUnit.test( "should parse skeleton", function( assert ) {
 	date.setHours( 17 );
 	date.setMinutes( 35 );
 	date.setSeconds( 7 );
-	date = startOf( date, "second" );
-	assertParseDate( assert, "Wed 5:35:07 PM", { skeleton: "Ehms" }, date );
+	date.setMilliseconds(734);
+	assertParseDate( assert, "Wed 5:35:07.734 PM", { skeleton: "EhmsSSS" }, date );
 
 	date = new Date( 2010, 8, 15 );
 	date = startOf( date, "day" );

--- a/test/unit/date/expand-pattern.js
+++ b/test/unit/date/expand-pattern.js
@@ -47,6 +47,7 @@ QUnit.test( "should expand {skeleton: \"<skeleton>\"}", function( assert ) {
 	assert.expandPattern( en, { skeleton: "hhmm" }, "hh:mm a" );
 	assert.expandPattern( en, { skeleton: "HHmm" }, "HH:mm" );
 	assert.expandPattern( en, { skeleton: "EHmss" }, "E HH:mm:ss" );
+	assert.expandPattern( en, { skeleton: "hhmmssSS" }, "hh:mm:ss.SS a" );
 	assert.expandPattern( en, { skeleton: "yy" }, "yy" );
 	assert.expandPattern( de, { skeleton: "yMMMMd" }, "d. MMMM y" );
 	assert.expandPattern( de, { skeleton: "MMMM" }, "LLLL" );
@@ -56,6 +57,7 @@ QUnit.test( "should expand {skeleton: \"<skeleton>\"}", function( assert ) {
 	assert.expandPattern( de, { skeleton: "MMMMEEEEd" }, "EEEE, d. MMMM" );
 	assert.expandPattern( de, { skeleton: "MMMMccccd" }, "EEEE, d. MMMM" );
 	assert.expandPattern( de, { skeleton: "HHmm" }, "HH:mm" );
+	assert.expandPattern( de, { skeleton: "HHmmssSS" }, "HH:mm:ss,SS" );
 	assert.expandPattern( de, { skeleton: "EEEEHHmm" }, "EEEE, HH:mm" );
 	assert.expandPattern( de, { skeleton: "EEEEHmm" }, "EEEE, HH:mm" );
 	assert.expandPattern( de, { skeleton: "ccccHmm" }, "EEEE, HH:mm" );

--- a/test/unit/date/expand-pattern/augment-format.js
+++ b/test/unit/date/expand-pattern/augment-format.js
@@ -5,29 +5,31 @@ define([
 QUnit.module( "Date Expand Pattern Augment Format" );
 
 QUnit.test( "should augment date skeletons", function( assert ) {
-	assert.equal( augmentFormat( "yy", "y" ), "yy" );
-	assert.equal( augmentFormat( "yMMdd", "M/d/y" ), "MM/dd/y" );
+	assert.equal( augmentFormat( "yy", "y", "." ), "yy" );
+	assert.equal( augmentFormat( "yMMdd", "M/d/y", "." ), "MM/dd/y" );
 
-	assert.equal( augmentFormat( "MMMMd", "MMM d" ), "MMMM d" );
-	assert.equal( augmentFormat( "MMMMd", "M d" ), "MMMM d" );
-	assert.equal( augmentFormat( "MMMMd", "'M' M d" ), "'M' MMMM d" );
+	assert.equal( augmentFormat( "MMMMd", "MMM d", "." ), "MMMM d" );
+	assert.equal( augmentFormat( "MMMMd", "M d", "." ), "MMMM d" );
+	assert.equal( augmentFormat( "MMMMd", "'M' M d", "." ), "'M' MMMM d" );
 
-	assert.equal( augmentFormat( "LLLL", "LLL" ), "LLLL" );
-	assert.equal( augmentFormat( "LLLLd", "MMM d" ), "MMMM d" );
+	assert.equal( augmentFormat( "LLLL", "LLL", "." ), "LLLL" );
+	assert.equal( augmentFormat( "LLLLd", "MMM d", "." ), "MMMM d" );
 
-	assert.equal( augmentFormat( "EEEE", "ccc" ), "cccc" );
-	assert.equal( augmentFormat( "EEEEd", "d E" ), "d EEEE" );
+	assert.equal( augmentFormat( "EEEE", "ccc", "." ), "cccc" );
+	assert.equal( augmentFormat( "EEEEd", "d E", "."), "d EEEE" );
 
-	assert.equal( augmentFormat( "cccc", "ccc" ), "cccc" );
-	assert.equal( augmentFormat( "ccccd", "d E" ), "d EEEE" );
+	assert.equal( augmentFormat( "cccc", "ccc", "." ), "cccc" );
+	assert.equal( augmentFormat( "ccccd", "d E", "." ), "d EEEE" );
 });
 
 QUnit.test( "should augment time skeletons", function( assert ) {
-	assert.equal( augmentFormat( "hhmm", "h:mm a" ), "hh:mm a" );
+	assert.equal( augmentFormat( "hhmm", "h:mm a", "." ), "hh:mm a" );
+	assert.equal( augmentFormat( "hhmmsS", "hh:mm:ss a", "." ), "hh:mm:ss.S a" );
+	assert.equal( augmentFormat( "hhmmssSSS", "hh:mm:ss a", "," ), "hh:mm:ss,SSS a" );
 });
 
 QUnit.test( "should augment datetime skeletons", function( assert ) {
-	assert.equal( augmentFormat( "EEEhhmmss", "E h:mm:ss a" ), "EEE hh:mm:ss a" );
+	assert.equal( augmentFormat( "EEEhhmmss", "E h:mm:ss a", "." ), "EEE hh:mm:ss a" );
 });
 
 });

--- a/test/unit/date/expand-pattern/get-best-match-pattern.js
+++ b/test/unit/date/expand-pattern/get-best-match-pattern.js
@@ -30,6 +30,7 @@ QUnit.test( "should get best match pattern", function( assert ) {
 	assert.equal( getBestMatchPattern( en, "cccd" ), "d EEE" );
 	assert.equal( getBestMatchPattern( en, "ccccd" ), "d EEEE" );
 
+	assert.equal( getBestMatchPattern( en, "hhmms" ), "hh:mm:ss a" );
 	assert.equal( getBestMatchPattern( en, "hhmmsS" ), "hh:mm:ss.S a" );
 });
 

--- a/test/unit/date/expand-pattern/get-best-match-pattern.js
+++ b/test/unit/date/expand-pattern/get-best-match-pattern.js
@@ -30,7 +30,7 @@ QUnit.test( "should get best match pattern", function( assert ) {
 	assert.equal( getBestMatchPattern( en, "cccd" ), "d EEE" );
 	assert.equal( getBestMatchPattern( en, "ccccd" ), "d EEEE" );
 
-	assert.equal( getBestMatchPattern( en, "hhmms" ), "hh:mm:ss a" );
+	assert.equal( getBestMatchPattern( en, "hhmmsS" ), "hh:mm:ss.S a" );
 });
 
 QUnit.test( "should be order-proof", function( assert ) {


### PR DESCRIPTION
Follows this algorithm:
http://www.unicode.org/reports/tr35/tr35-dates.html#Matching_Skeletons

Fixes #753