### PR TITLE
Examples: Make basic globalize-compiler example more generic

### DIFF
--- a/examples/globalize-compiler/app.js
+++ b/examples/globalize-compiler/app.js
@@ -1,8 +1,5 @@
 var like, number;
 
-// Set default locale as "en".
-Globalize.locale( "en" );
-
 // Use Globalize to format dates.
 document.getElementById( "date" ).textContent = Globalize.formatDate( new Date(), {
 	datetime: "medium"

--- a/examples/globalize-compiler/app.js
+++ b/examples/globalize-compiler/app.js
@@ -1,5 +1,8 @@
 var like, number;
 
+// Set default locale as "en".
+Globalize.locale( "en" );
+
 // Use Globalize to format dates.
 document.getElementById( "date" ).textContent = Globalize.formatDate( new Date(), {
 	datetime: "medium"

--- a/examples/globalize-compiler/development.html
+++ b/examples/globalize-compiler/development.html
@@ -109,7 +109,6 @@
       Globalize.load( weekData[ 0 ] );
       Globalize.loadMessages( messages[ 0 ] );
       Globalize.loadTimeZone( ianaTzData[ 0 ] );
-      Globalize.locale("en");
 
       // Load and execute our App.
       $.getScript( "app.js" );

--- a/examples/globalize-compiler/development.html
+++ b/examples/globalize-compiler/development.html
@@ -109,6 +109,7 @@
       Globalize.load( weekData[ 0 ] );
       Globalize.loadMessages( messages[ 0 ] );
       Globalize.loadTimeZone( ianaTzData[ 0 ] );
+      Globalize.locale("en");
 
       // Load and execute our App.
       $.getScript( "app.js" );


### PR DESCRIPTION
Examples

Move  Globalize.locale('en') to development.html

Fixes #637 