### PR TITLE
upgrade cldrjs dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "bower.json"
   ],
   "dependencies": {
-    "cldrjs": "^0.4.4"
+    "cldrjs": "^0.5.0"
   },
   "devDependencies": {
     "cldr-data": ">=25",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "url": "http://github.com/jquery/globalize/issues"
   },
   "dependencies": {
-    "cldrjs": "^0.4.6"
+    "cldrjs": "^0.5.0"
   },
   "devDependencies": {
     "cldr-data-downloader": "^0.2.5",


### PR DESCRIPTION
There is a bug fix in the 0.5.0 that I'll need, so please upgrade the cldrjs dependency.

Minor version bumps in the `0.x.x` version range is defined as major by npm and by that not covered with `^`.