### PR TITLE
Currency: currency parsing

### DIFF
--- a/src/currency.js
+++ b/src/currency.js
@@ -149,10 +149,11 @@ Globalize.parseCurrency =
 Globalize.prototype.parseCurrency = function( value, options ) {
 	validateParameterPresence( value, "value" );
 
-	value = value.replace(/[^\d\.\,]/g, "");
-	value = this.numberParser(value);
+	value = value.replace( /[^\d\.\,]/g, "" );
+	value = this.numberParser( value );
 
 	this.currencyParser( options )( value );
+
 	return value;
 };
 

--- a/src/currency.js
+++ b/src/currency.js
@@ -114,7 +114,7 @@ Globalize.prototype.currencyParser = function( options ) {
 	// returnFn = numberParser(value)
 
 	runtimeBind( args, returnFn, [ numberParser, properties ] );
-	return returnFn
+	return returnFn;
 };
 
 /**
@@ -149,10 +149,10 @@ Globalize.parseCurrency =
 Globalize.prototype.parseCurrency = function( value, options ) {
 	validateParameterPresence( value, "value" );
 
-	value = value.replace(/[^\d\.\,]/g, '');
-	value = this.numberParser(value)
+	value = value.replace(/[^\d\.\,]/g, "");
+	value = this.numberParser(value);
 
-	// return this.currencyParser( options )( value );
+	this.currencyParser( options )( value );
 	return value;
 };
 

--- a/src/currency.js
+++ b/src/currency.js
@@ -148,7 +148,7 @@ Globalize.prototype.formatCurrency = function( value, currency, options ) {
 Globalize.parseCurrency =
 Globalize.prototype.parseCurrency = function( value, options ) {
 	validateParameterPresence( value, "value" );
-
+	
 	value = value.replace( /[^\d\.\,]/g, "" );
 	value = this.numberParser( value );
 

--- a/src/currency.js
+++ b/src/currency.js
@@ -148,7 +148,14 @@ Globalize.prototype.formatCurrency = function( value, currency, options ) {
 Globalize.parseCurrency =
 Globalize.prototype.parseCurrency = function( value, options ) {
 	validateParameterPresence( value, "value" );
-	value = value.replace( /[^\d\.\,]/g, "" );
+	value = value.replace( /[^\d\.\,\-]/g, "" );
+	if ( value[0] === "-" ) {
+		value = value.replace( "-", "" );
+		value = "-".concat(value);
+	}
+	else {
+		value = value.replace( "-", "" );
+	}
 	value = this.numberParser( value );
 
 	this.currencyParser( options )( value );

--- a/src/currency.js
+++ b/src/currency.js
@@ -94,17 +94,27 @@ Globalize.prototype.currencyFormatter = function( currency, options ) {
 /**
  * .currencyParser( currency [, options] )
  *
- * @currency [String] 3-letter currency code as defined by ISO 4217.
- *
  * @options [Object] see currencyFormatter.
  *
  * Return the currency parser according to the given options and the default/instance locale.
  */
 Globalize.currencyParser =
-Globalize.prototype.currencyParser = function( /* currency, options */ ) {
+Globalize.prototype.currencyParser = function( options ) {
+	var args, numberParser, properties, returnFn;
 
-	// TODO implement parser.
+	validateParameterTypePlainObject( options, "options" );
 
+	options = options || {};
+
+	args = [ options ];
+
+	numberParser = this.numberParser( options );
+
+	// value.replace(/[^\d\.\,]/g, '');
+	// returnFn = numberParser(value)
+
+	runtimeBind( args, returnFn, [ numberParser, properties ] );
+	return returnFn
 };
 
 /**
@@ -131,15 +141,22 @@ Globalize.prototype.formatCurrency = function( value, currency, options ) {
  *
  * @value [String]
  *
- * @currency [String] 3-letter currency code as defined by ISO 4217.
- *
  * @options [Object]: See currencyFormatter.
  *
  * Return the parsed currency or NaN when value is invalid.
  */
 Globalize.parseCurrency =
-Globalize.prototype.parseCurrency = function( /* value, currency, options */ ) {
+Globalize.prototype.parseCurrency = function( value, options ) {
+	validateParameterPresence( value, "value" );
+
+	value = value.replace(/[^\d\.\,]/g, '');
+	value = this.numberParser(value)
+
+	// return this.currencyParser( options )( value );
+	return value;
 };
+
+
 
 return Globalize;
 

--- a/src/currency.js
+++ b/src/currency.js
@@ -151,9 +151,8 @@ Globalize.prototype.parseCurrency = function( value, options ) {
 	value = value.replace( /[^\d\.\,\-]/g, "" );
 	if ( value[0] === "-" ) {
 		value = value.replace( "-", "" );
-		value = "-".concat(value);
-	}
-	else {
+		value = "-".concat( value );
+	} else {
 		value = value.replace( "-", "" );
 	}
 	value = this.numberParser( value );

--- a/src/currency.js
+++ b/src/currency.js
@@ -157,7 +157,6 @@ Globalize.prototype.parseCurrency = function( value, options ) {
 	return value;
 };
 
-
 return Globalize;
 
 });

--- a/src/currency.js
+++ b/src/currency.js
@@ -158,7 +158,6 @@ Globalize.prototype.parseCurrency = function( value, options ) {
 };
 
 
-
 return Globalize;
 
 });

--- a/src/currency.js
+++ b/src/currency.js
@@ -148,7 +148,6 @@ Globalize.prototype.formatCurrency = function( value, currency, options ) {
 Globalize.parseCurrency =
 Globalize.prototype.parseCurrency = function( value, options ) {
 	validateParameterPresence( value, "value" );
-	
 	value = value.replace( /[^\d\.\,]/g, "" );
 	value = this.numberParser( value );
 

--- a/test/functional/currency/currency-parser.js
+++ b/test/functional/currency/currency-parser.js
@@ -1,0 +1,146 @@
+define([
+	"globalize",
+	"json!cldr-data/main/de/currencies.json",
+	"json!cldr-data/main/de/numbers.json",
+	"json!cldr-data/main/en/currencies.json",
+	"json!cldr-data/main/en/numbers.json",
+	"json!cldr-data/main/zh/currencies.json",
+	"json!cldr-data/main/zh/numbers.json",
+	"json!cldr-data/supplemental/currencyData.json",
+	"json!cldr-data/supplemental/likelySubtags.json",
+	"json!cldr-data/supplemental/plurals.json",
+	"../../util",
+
+	"globalize/currency",
+	"globalize/number",
+	"globalize/plural"
+], function( Globalize, deCurrencies, deNumbers, enCurrencies, enNumbers, zhCurrencies,
+	zhNumbers, currencyData, likelySubtags, plurals, util ) {
+
+var teslaS = 69900;
+
+function extraSetup() {
+	Globalize.load(
+		currencyData,
+		deCurrencies,
+		deNumbers,
+		enCurrencies,
+		enNumbers,
+		plurals,
+		zhCurrencies,
+		zhNumbers
+	);
+
+}
+
+QUnit.module( ".currencyParser( [options] )", {
+	setup: function() {
+		Globalize.load( likelySubtags, {
+			main: {
+				en: {},
+				"en-IN": {},
+				"tr-CY": {}
+			}
+		});
+		Globalize.locale( "en" );
+	},
+	teardown: util.resetCldrContent
+});
+
+QUnit.test( "should validate parameters", function( assert ) {
+	util.assertParameterPresence( assert, "currency", function() {
+		Globalize.currencyParser();
+	});
+
+	util.assertCurrencyParameter( assert, "currency", function( invalidValue ) {
+		return function() {
+			Globalize.currencyParser( invalidValue );
+		};
+	});
+
+	util.assertPlainObjectParameter( assert, "options", function( invalidValue ) {
+		return function() {
+			Globalize.currencyParser( invalidValue );
+		};
+	});
+});
+
+QUnit.test( "should validate CLDR content", function( assert ) {
+	util.assertCldrContent( assert, function() {
+		Globalize.currencyParser();
+	});
+});
+
+QUnit.test( "should return a currency formatter", function( assert ) {
+	var de, zh;
+
+	extraSetup();
+
+	de = Globalize( "de" );
+	zh = Globalize( "zh" );
+
+	assert.equal( Globalize.currencyParser()( "$69,900.00" ), teslaS );
+	assert.equal( de.currencyParser()( "69.900,00 $" ), teslaS );
+	assert.equal( zh.currencyParser()( "US$69,900.00" ), teslaS );
+
+	assert.equal( Globalize.currencyParser()( "-$69,900.00" ), -teslaS );
+	assert.equal( de.currencyParser()( "-69.900,00 $" ), -teslaS );
+	assert.equal( zh.currencyParser()( "-US$69,900.00" ), -teslaS );
+
+	assert.equal( Globalize.currencyParser()( "69,900.00 USD" ), teslaS );
+	assert.equal( de.currencyParser()( "69.900,00 USD" ), teslaS );
+	assert.equal( zh.currencyParser()( "69,900.00USD" ), teslaS );
+
+	assert.equal( Globalize.currencyParser()( "69,900.00 US dollars" ), teslaS );
+	assert.equal( de.currencyParser()( "69.900,00 US-Dollar" ), teslaS );
+	assert.equal( zh.currencyParser()( "69,900.00美元" ), teslaS );
+
+	assert.equal( Globalize.currencyParser()( "($1.00)" ), -1 );
+});
+
+// The number of decimal places and the rounding for each currency is not locale-specific data.
+// Those values are overriden by Supplemental Currency Data.
+QUnit.test( "should return a currency formatter, overriden by Supplemental Currency Data",
+			function( assert ) {
+	extraSetup();
+
+	assert.equal( Globalize.currencyParser()( "CLF 12,345.0000" ), 12345 );
+	assert.equal( Globalize.currencyParser()( "CLF 12,345.6700" ), 12345.67 );
+	assert.equal( Globalize.currencyParser()( "ZWD 12,345" ), 12345 );
+	assert.equal( Globalize.currencyParser()( "ZWD 12,346" ), 12345.67 );
+	assert.equal( Globalize.currencyParser()( "¥12,346" ), 12345.67 );
+
+	assert.equal( Globalize.currencyParser()( "12,345.6700 CLF" ), 12345.67 );
+
+	assert.equal( Globalize.currencyParser()( "12,345.6700 Chilean units of account (UF)" ), 12345.67 );
+});
+
+// User options should override everything.
+QUnit.test( "should return a currency formatter, overriden by user options",
+			function( assert ) {
+	extraSetup();
+
+	assert.equal( Globalize.currencyParser({
+		minimumFractionDigits: 0
+	})( "CLF 12,345" ), 12345 );
+
+	assert.equal( Globalize.currencyParser({
+		maximumFractionDigits: 0
+	})( "¥12,345" ), 12345 );
+
+	assert.equal( Globalize.currencyParser({
+		minimumFractionDigits: 2
+	})( "¥12,345.00" ), 12345 );
+
+	assert.equal( Globalize.currencyParser({
+		style: "code",
+		minimumFractionDigits: 0
+	})( "12,345 CLF" ), 12345 );
+
+	assert.equal( Globalize.currencyParser({
+		style: "name",
+		minimumFractionDigits: 0
+	})( "12,345 Chilean units of account (UF)" ), 12345 );
+});
+
+});

--- a/test/functional/currency/parse-currency.js
+++ b/test/functional/currency/parse-currency.js
@@ -1,0 +1,76 @@
+define([
+	"globalize",
+	"json!cldr-data/main/en/currencies.json",
+	"json!cldr-data/main/en/numbers.json",
+	"json!cldr-data/supplemental/currencyData.json",
+	"json!cldr-data/supplemental/likelySubtags.json",
+	"json!cldr-data/supplemental/plurals.json",
+	"../../util",
+
+	"globalize/currency",
+	"globalize/number"
+], function( Globalize, enCurrencies, enNumbers, currencyData, likelySubtags, plurals, util ) {
+
+var teslaS = 69900;
+
+function extraSetup() {
+	Globalize.load(
+		currencyData,
+		enCurrencies,
+		enNumbers,
+		plurals
+	);
+}
+
+QUnit.module( ".formatCurrency( value, currency [, options] )", {
+	setup: function() {
+		Globalize.load( likelySubtags, {
+			main: {
+				en: {}
+			}
+		});
+		Globalize.locale( "en" );
+	},
+	teardown: util.resetCldrContent
+});
+
+QUnit.test( "should validate parameters", function( assert ) {
+	util.assertParameterPresence( assert, "value", function() {
+		Globalize.formatCurrency();
+	});
+
+	util.assertNumberParameter( assert, "value", function( invalidValue ) {
+		return function() {
+			Globalize.formatCurrency( invalidValue );
+		};
+	});
+
+	util.assertParameterPresence( assert, "currency", function() {
+		Globalize.formatCurrency( 7 );
+	});
+
+	util.assertCurrencyParameter( assert, "currency", function( invalidValue ) {
+		return function() {
+			Globalize.formatCurrency( 7, invalidValue );
+		};
+	});
+
+	util.assertPlainObjectParameter( assert, "options", function( invalidValue ) {
+		return function() {
+			Globalize.formatCurrency( 7, "USD", invalidValue );
+		};
+	});
+});
+
+QUnit.test( "should validate CLDR content", function( assert ) {
+	util.assertCldrContent( assert, function() {
+		Globalize.formatCurrency( 7, "USD" );
+	});
+});
+
+QUnit.test( "should format currencies", function( assert ) {
+	extraSetup();
+	assert.equal( Globalize.formatCurrency( teslaS, "USD" ), "$69,900.00" );
+});
+
+});


### PR DESCRIPTION
Adding [currency parsing](https://github.com/globalizejs/globalize/issues/364) to currency.js by:

1. Parse the currency string for numbers, commas, and periods: `valueString.replace(/[^\d\.\,]/g, '')`
2. Run `numberParser`

Currency codes define the symbols and locale defines the number format. If we're just parsing the number, we can strip away the symbols and parse the number in the locale specified in the settings