### PR TITLE
Fix leaking handler in date format setup

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -164,7 +164,7 @@ Globalize.prototype.dateFormatter = function( options ) {
 Globalize.dateToPartsFormatter =
 Globalize.prototype.dateToPartsFormatter = function( options ) {
 	var args, cldr, numberFormatters, pad, pattern, properties, returnFn,
-		timeZone;
+		timeZone, ianaListener;
 
 	validateParameterTypePlainObject( options, "options" );
 
@@ -184,14 +184,15 @@ Globalize.prototype.dateToPartsFormatter = function( options ) {
 
 	cldr.on( "get", validateRequiredCldr );
 	if ( timeZone ) {
-		cldr.on( "get", validateRequiredIana( timeZone ) );
+		ianaListener = validateRequiredIana( timeZone );
+		cldr.on( "get", ianaListener );
 	}
 	pattern = dateExpandPattern( options, cldr );
 	validateOptionsSkeleton( pattern, options.skeleton );
 	properties = dateFormatProperties( pattern, cldr, timeZone );
 	cldr.off( "get", validateRequiredCldr );
-	if ( timeZone ) {
-		cldr.off( "get", validateRequiredIana( timeZone ) );
+	if ( ianaListener ) {
+		cldr.off( "get", ianaListener );
 	}
 
 	// Create needed number formatters.


### PR DESCRIPTION
A coworker of mine patched this locally because we were experiencing progressive slow-downs the more we rendered certain pages with lots of dates.

> They are adding and removing an event listener from cldr when we pass in options.timeZone, but since they are constructing the listener with a generator function, they aren't actually removing the one they added. I'll see if I can modify this function and check if that fixes it.

<3z,
Alex