### PR TITLE
Number: Compact formatting with significat digits fix

### DIFF
--- a/src/util/number/to-precision.js
+++ b/src/util/number/to-precision.js
@@ -14,10 +14,6 @@ define(function() {
 return function( number, precision, round ) {
 	var roundOrder;
 
-	// Get number at two extra significant figure precision.
-	number = number.toPrecision( precision + 2 );
-
-	// Then, round it to the required significant figure precision.
 	roundOrder = Math.ceil( Math.log( Math.abs( number ) ) / Math.log( 10 ) );
 	roundOrder -= precision;
 

--- a/test/unit/number/format.js
+++ b/test/unit/number/format.js
@@ -462,6 +462,18 @@ QUnit.test( "numbers should support significant digits in compact mode", functio
 		maximumSignificantDigits: 3,
 		minimumSignificantDigits: 1
 	})), "-127M" );
+
+	assert.equal( format( 12849872883, properties("0", en, {
+		minimumSignificantDigits: 1,
+		maximumSignificantDigits: 3,
+		compact: "short"
+	})), "12.8B" );
+	
+	assert.equal( format( 12850172883, properties("0", en, {
+		minimumSignificantDigits: 1,
+		maximumSignificantDigits: 3,
+		compact: "short"
+	})), "12.9B" );
 });
 
 QUnit.test( "numbers should support rounding in compact mode", function( assert ) {


### PR DESCRIPTION
Fixes: #821 

Removed the logic of rounding the number twice - with a precision of {actual precision required + 2} and then again with the actual precision. This was causing wrong rounding off a number. For eg. 

```
Globalize.numberFormatter({
        minimumSignificantDigits: 1,
        maximumSignificantDigits: 3,
    })(12.849872883)
```

Here the number 12.849872883 is first converted to 12.850 and then when finally rounded off becomes 12.9. But Ideally this should be formatted to 12.8.