### PR TITLE
removeLiteralQuotes: Escape '' as a single quote '

### DIFF
--- a/src/util/remove-literal-quotes.js
+++ b/src/util/remove-literal-quotes.js
@@ -4,7 +4,7 @@ define(function() {
  * removeLiteralQuotes( string )
  *
  * Return:
- * - `` if input string is `''`.
+ * - `'` if input string is `''`.
  * - `o'clock` if input string is `'o''clock'`.
  * - `foo` if input string is `foo`, i.e., return the same value in case it isn't a single-quoted
  *   string.
@@ -14,7 +14,7 @@ return function( string ) {
 		return string;
 	}
 	if ( string === "''" ) {
-		return "";
+		return "'";
 	}
 	return string.replace( /''/g, "'" ).slice( 1, -1 );
 };


### PR DESCRIPTION
According to:

> To create a single quote itself, use two in a row: "# o''clock".

https://www.unicode.org/reports/tr35/tr35-numbers.html#Number_Pattern_Character_Definitions