### PR TITLE
Fix dayPeriod and timeZoneName in documentation

### DIFF
--- a/doc/api/date/date-to-parts-formatter.md
+++ b/doc/api/date/date-to-parts-formatter.md
@@ -60,7 +60,7 @@ Possible types are the following:
 
   The string used for the second, e.g., `"07"` or `"42"`.
 
-- `timeZoneName`
+- `zone`
 
   The string used for the name of the time zone, e.g., `"EST".`
 

--- a/doc/api/date/date-to-parts-formatter.md
+++ b/doc/api/date/date-to-parts-formatter.md
@@ -31,7 +31,7 @@ Possible types are the following:
 
   The string used for the day, e.g., `"17"`, `"١٦"`.
 
-- `dayPeriod`
+- `dayperiod`
 
   The string used for the day period, e.g., `"AM"`, `"PM"`.
 


### PR DESCRIPTION
Globalize actually returns lower case `dayperiod`. But the documentation says `dayPeriod`.

This is confusing because `Intl.DateTimeFormat`'s `formatToParts` does return `dayPeriod` but Globalize diverges from this and returns lower case `dayperiod`. This mistake in the documentation can lead to tricky bugs where a developer writes code according to the documentation checking for `dayPeriod` which doesn't work.