### PR TITLE
Bump CLDRjs to 0.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "url": "http://github.com/jquery/globalize/issues"
   },
   "dependencies": {
-    "cldrjs": "^0.5.0"
+    "cldrjs": "^0.5.4"
   },
   "devDependencies": {
     "cldr-data-downloader": "^0.3.1",


### PR DESCRIPTION
Latest version contains multiple fixes and improvements which would be good to have in Globalize :)

Signed-off-by: Georgi Tsaklev <georgi.tsaklev@skyscanner.net>