### PR TITLE
Build: Update to QUnit 2

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -236,7 +236,8 @@ module.exports = function( grunt ) {
 					// ZonedDateTime
 					} else if ( ( /zoned-date-time/ ).test( id ) ) {
 						contents = contents.replace(
-							"module.exports = ZonedDateTime;",
+							"if (typeof module !== \"undefined\" && module.exports) {\n" +
+								"  module.exports = ZonedDateTime;\n}",
 							"return ZonedDateTime;"
 						);
 						contents = "var ZonedDateTime = (function() {\n" + contents + "}());";

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,9 +33,9 @@ module.exports = function( grunt ) {
 			order: "count"
 		},
 		commitplease: {
-			last50: {
+			last: {
 				options: {
-					committish: "-n 50"
+					committish: "-n 5"
 				}
 			}
 		},

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,6 @@
     "es5-shim": "3.4.0",
     "make-plural": "eemeli/make-plural.js#3.0.0",
     "messageformat": "SlexAxton/messageformat.js#v0.3.0-1",
-    "qunit": "1.23.1",
     "requirejs": "2.1.20",
     "requirejs-plugins": "1.0.2",
     "requirejs-text": "2.0.10"

--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "es5-shim": "3.4.0",
     "make-plural": "eemeli/make-plural.js#3.0.0",
     "messageformat": "SlexAxton/messageformat.js#v0.3.0-1",
-    "qunit": "1.18.0",
+    "qunit": "1.23.1",
     "requirejs": "2.1.20",
     "requirejs-plugins": "1.0.2",
     "requirejs-text": "2.0.10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2227,6 +2227,18 @@
         "type-fest": "^0.8.1"
       }
     },
+    "globalyzer": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.4.tgz",
+      "integrity": "sha512-LeguVWaxgHN0MNbWC6YljNMzHkrCny9fzjmEUdnF1kQ7wATFD1RHFRqA1qxaX2tgxGENlcxjOflopBwj3YZiXA==",
+      "dev": true
+    },
+    "globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
+    },
     "globule": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.2.tgz",
@@ -3129,6 +3141,12 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
+    "js-reporters": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/js-reporters/-/js-reporters-1.2.3.tgz",
+      "integrity": "sha512-2YzWkHbbRu6LueEs5ZP3P1LqbECvAeUJYrjw3H4y1ofW06hqCS0AbzBtLwbr+Hke51bt9CUepJ/Fj1hlCRIF6A==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3825,6 +3843,12 @@
       "integrity": "sha1-9F+vn6gz7TylElDqmn3fxCZ6RLM=",
       "dev": true
     },
+    "node-watch": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.0.tgz",
+      "integrity": "sha512-OOBiglke5SlRQT5WYfwXTmYqTfXjcTNBHpalyHLtLxDpQYVpVRkJqabcch1kmwJsjV/J4OZuzEafeb4soqtFZA==",
+      "dev": true
+    },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
@@ -4332,6 +4356,26 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
+    },
+    "qunit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.12.0.tgz",
+      "integrity": "sha512-Lu3tbKziVzXTfseoEtTiiSAbSPB6SGU4Emc2uo8n+fbsXuRCLzfqPwJfAVJwKu9NdukX1V/L0qWf2UvmPX+QeA==",
+      "dev": true,
+      "requires": {
+        "commander": "6.2.0",
+        "js-reporters": "1.2.3",
+        "node-watch": "0.7.0",
+        "tiny-glob": "0.2.6"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+          "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+          "dev": true
+        }
+      }
     },
     "randomatic": {
       "version": "3.1.1",
@@ -5106,6 +5150,16 @@
       "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
       "dev": true
     },
+    "tiny-glob": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.6.tgz",
+      "integrity": "sha512-A7ewMqPu1B5PWwC3m7KVgAu96Ch5LA0w4SnEN/LbDREj/gAD0nPWboRbn8YoP9ISZXqeNAlMvKSKoEuhcfK3Pw==",
+      "dev": true,
+      "requires": {
+        "globalyzer": "^0.1.0",
+        "globrex": "^0.1.1"
+      }
+    },
     "tiny-lr": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-0.2.1.tgz",
@@ -5623,9 +5677,9 @@
       }
     },
     "zoned-date-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/zoned-date-time/-/zoned-date-time-1.0.0.tgz",
-      "integrity": "sha1-2AkmYV22oasvdy9OtNOPIss2JKY=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/zoned-date-time/-/zoned-date-time-1.1.0.tgz",
+      "integrity": "sha512-MhjAUwM1ABOmE9J5SzjNnoXQL83NDaZbRYsZtVTTIjKxXeGJ70GZNEC/NJAyhYiyFiteu24N8Q6gaGhOI/A51A==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -95,8 +95,9 @@
     "iana-tz-data": ">=2017.0.0",
     "matchdep": "1.0.1",
     "mocha": "^3.4.2",
+    "qunit": "2.12.0",
     "semver": "^5.3.0",
-    "zoned-date-time": "1.0.0"
+    "zoned-date-time": "1.1.0"
   },
   "commitplease": {
     "nohook": true

--- a/test/config.js
+++ b/test/config.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-unused-vars
 var requirejs = {
 	paths: {
-		qunit: "../external/qunit/qunit/qunit",
+		qunit: "../node_modules/qunit/qunit/qunit",
 		cldr: "../external/cldrjs/dist/cldr",
 		"cldr-data": "../external/cldr-data",
 		globalize: "../dist/globalize",

--- a/test/functional-es5-shim.html
+++ b/test/functional-es5-shim.html
@@ -1,9 +1,9 @@
-<!doctype html>
+<!DOCTYPE html>
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>Globalize Functional Tests</title>
-    <link rel="stylesheet" href="../external/qunit/qunit/qunit.css">
+    <link rel="stylesheet" href="../node_modules/qunit/qunit/qunit.css">
 </head>
 <body>
     <div id="qunit"></div>

--- a/test/functional.html
+++ b/test/functional.html
@@ -1,10 +1,10 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>Globalize Functional Tests</title>
-    <link rel="stylesheet" href="../external/qunit/qunit/qunit.css">
+    <link rel="stylesheet" href="../node_modules/qunit/qunit/qunit.css">
 </head>
 <body>
     <div id="qunit"></div>

--- a/test/functional.js
+++ b/test/functional.js
@@ -48,7 +48,7 @@ require([
 	QUnit.start();
 }, function( error ) {
 	QUnit.test( "requirejs load failure", function( assert ) {
-		assert.ok( false, "requirejs failed to load: " + QUnit.jsDump.parse( error ) );
+		assert.ok( false, "requirejs failed to load: " + QUnit.dump.parse( error ) );
 	});
 	QUnit.start();
 });

--- a/test/functional/currency/currency-formatter.js
+++ b/test/functional/currency/currency-formatter.js
@@ -38,7 +38,7 @@ function extraSetup() {
 }
 
 QUnit.module( ".currencyFormatter( currency [, options] )", {
-	setup: function() {
+	beforeEach: function() {
 		Globalize.load( likelySubtags, {
 			main: {
 				en: {}
@@ -46,7 +46,7 @@ QUnit.module( ".currencyFormatter( currency [, options] )", {
 		});
 		Globalize.locale( "en" );
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 QUnit.test( "should validate parameters", function( assert ) {

--- a/test/functional/currency/currency-to-parts-formatter.js
+++ b/test/functional/currency/currency-to-parts-formatter.js
@@ -38,7 +38,7 @@ function extraSetup() {
 }
 
 QUnit.module( ".currencyToPartsFormatter( currency [, options] )", {
-	setup: function() {
+	beforeEach: function() {
 		Globalize.load( likelySubtags, {
 			main: {
 				en: {}
@@ -46,7 +46,7 @@ QUnit.module( ".currencyToPartsFormatter( currency [, options] )", {
 		});
 		Globalize.locale( "en" );
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 QUnit.test( "should validate parameters", function( assert ) {

--- a/test/functional/currency/format-currency-to-parts.js
+++ b/test/functional/currency/format-currency-to-parts.js
@@ -23,7 +23,7 @@ function extraSetup() {
 }
 
 QUnit.module( ".formatCurrencyToParts( value, currency [, options] )", {
-	setup: function() {
+	beforeEach: function() {
 		Globalize.load( likelySubtags, {
 			main: {
 				en: {}
@@ -31,7 +31,7 @@ QUnit.module( ".formatCurrencyToParts( value, currency [, options] )", {
 		});
 		Globalize.locale( "en" );
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 QUnit.test( "should validate parameters", function( assert ) {

--- a/test/functional/currency/format-currency.js
+++ b/test/functional/currency/format-currency.js
@@ -23,7 +23,7 @@ function extraSetup() {
 }
 
 QUnit.module( ".formatCurrency( value, currency [, options] )", {
-	setup: function() {
+	beforeEach: function() {
 		Globalize.load( likelySubtags, {
 			main: {
 				en: {}
@@ -31,7 +31,7 @@ QUnit.module( ".formatCurrency( value, currency [, options] )", {
 		});
 		Globalize.locale( "en" );
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 QUnit.test( "should validate parameters", function( assert ) {

--- a/test/functional/date/date-formatter.js
+++ b/test/functional/date/date-formatter.js
@@ -25,7 +25,7 @@ function extraSetup() {
 }
 
 QUnit.module( ".dateFormatter( pattern )", {
-	setup: function() {
+	beforeEach: function() {
 		Globalize.load( likelySubtags, {
 			main: {
 				en: {}
@@ -33,7 +33,7 @@ QUnit.module( ".dateFormatter( pattern )", {
 		});
 		Globalize.locale( "en" );
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 QUnit.test( "should validate parameters", function( assert ) {

--- a/test/functional/date/date-parser.js
+++ b/test/functional/date/date-parser.js
@@ -31,7 +31,7 @@ function extraSetup() {
 }
 
 QUnit.module( ".dateParser( pattern )", {
-	setup: function() {
+	beforeEach: function() {
 		Globalize.load( likelySubtags, {
 			main: {
 				en: {}
@@ -39,7 +39,7 @@ QUnit.module( ".dateParser( pattern )", {
 		});
 		Globalize.locale( "en" );
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 QUnit.test( "should validate parameters", function( assert ) {

--- a/test/functional/date/date-to-parts-formatter.js
+++ b/test/functional/date/date-to-parts-formatter.js
@@ -25,7 +25,7 @@ function extraSetup() {
 }
 
 QUnit.module( ".dateToPartsFormatter( pattern )", {
-	setup: function() {
+	beforeEach: function() {
 		Globalize.load( likelySubtags, {
 			main: {
 				en: {}
@@ -33,7 +33,7 @@ QUnit.module( ".dateToPartsFormatter( pattern )", {
 		});
 		Globalize.locale( "en" );
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 QUnit.test( "should validate parameters", function( assert ) {

--- a/test/functional/date/format-date-to-parts.js
+++ b/test/functional/date/format-date-to-parts.js
@@ -41,7 +41,7 @@ function extraSetup() {
 }
 
 QUnit.module( ".formatDateToParts( value, options )", {
-	setup: function() {
+	beforeEach: function() {
 		Globalize.load( likelySubtags, {
 			main: {
 				en: {}
@@ -49,7 +49,7 @@ QUnit.module( ".formatDateToParts( value, options )", {
 		});
 		Globalize.locale( "en" );
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 QUnit.test( "should validate parameters (1/2)", function( assert ) {

--- a/test/functional/date/format-date.js
+++ b/test/functional/date/format-date.js
@@ -43,7 +43,7 @@ function extraSetup() {
 }
 
 QUnit.module( ".formatDate( value, options )", {
-	setup: function() {
+	beforeEach: function() {
 		Globalize.load( likelySubtags, {
 			main: {
 				en: {}
@@ -51,7 +51,7 @@ QUnit.module( ".formatDate( value, options )", {
 		});
 		Globalize.locale( "en" );
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 QUnit.test( "should validate parameters (1/2)", function( assert ) {

--- a/test/functional/date/parse-date.js
+++ b/test/functional/date/parse-date.js
@@ -43,7 +43,7 @@ function extraSetup() {
 }
 
 QUnit.module( ".parseDate( value, options )", {
-	setup: function() {
+	beforeEach: function() {
 		Globalize.load( likelySubtags, {
 			main: {
 				en: {}
@@ -51,7 +51,7 @@ QUnit.module( ".parseDate( value, options )", {
 		});
 		Globalize.locale( "en" );
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 function assertParseDate( assert, input, options, output, globalize ) {

--- a/test/functional/message/format-message.js
+++ b/test/functional/message/format-message.js
@@ -9,7 +9,7 @@ define([
 ], function( Globalize, likelySubtags, plurals, util ) {
 
 QUnit.module( ".formatMessage( path [, variables] )", {
-	setup: function() {
+	beforeEach: function() {
 		Globalize.load( likelySubtags );
 		Globalize.load( plurals );
 		Globalize.loadMessages({
@@ -20,7 +20,7 @@ QUnit.module( ".formatMessage( path [, variables] )", {
 			}
 		});
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 QUnit.test( "should validate parameters", function( assert ) {

--- a/test/functional/message/message-formatter.js
+++ b/test/functional/message/message-formatter.js
@@ -25,7 +25,7 @@ QUnit.assert.messageBundlePresence = function( fn ) {
 };
 
 QUnit.module( ".messageFormatter( path )", {
-	setup: function() {
+	beforeEach: function() {
 		Globalize.load( likelySubtags );
 		Globalize.load( plurals );
 		Globalize.loadMessages({
@@ -73,7 +73,7 @@ QUnit.module( ".messageFormatter( path )", {
 			}
 		});
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 QUnit.test( "should pass test's prerequisites", function( assert ) {

--- a/test/functional/number/format-number-to-parts.js
+++ b/test/functional/number/format-number-to-parts.js
@@ -25,7 +25,7 @@ function extraSetup() {
 }
 
 QUnit.module( ".formatNumberToParts( value [, options] )", {
-	setup: function() {
+	beforeEach: function() {
 		Globalize.load( likelySubtags, {
 			main: {
 				en: {}
@@ -33,7 +33,7 @@ QUnit.module( ".formatNumberToParts( value [, options] )", {
 		});
 		Globalize.locale( "en" );
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 QUnit.test( "should validate parameters", function( assert ) {

--- a/test/functional/number/format-number.js
+++ b/test/functional/number/format-number.js
@@ -25,7 +25,7 @@ function extraSetup() {
 }
 
 QUnit.module( ".formatNumber( value [, options] )", {
-	setup: function() {
+	beforeEach: function() {
 		Globalize.load( likelySubtags, {
 			main: {
 				en: {}
@@ -33,7 +33,7 @@ QUnit.module( ".formatNumber( value [, options] )", {
 		});
 		Globalize.locale( "en" );
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 QUnit.test( "should validate parameters", function( assert ) {

--- a/test/functional/number/number-formatter.js
+++ b/test/functional/number/number-formatter.js
@@ -20,7 +20,7 @@ function extraSetup() {
 }
 
 QUnit.module( ".numberFormatter( [options] )", {
-	setup: function() {
+	beforeEach: function() {
 		Globalize.load( likelySubtags, {
 			main: {
 				en: {}
@@ -28,7 +28,7 @@ QUnit.module( ".numberFormatter( [options] )", {
 		});
 		Globalize.locale( "en" );
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 QUnit.test( "should validate parameters", function( assert ) {

--- a/test/functional/number/number-parser.js
+++ b/test/functional/number/number-parser.js
@@ -16,7 +16,7 @@ function extraSetup() {
 }
 
 QUnit.module( ".numberParser( [options] )", {
-	setup: function() {
+	beforeEach: function() {
 		Globalize.load( likelySubtags, {
 			main: {
 				en: {},
@@ -26,7 +26,7 @@ QUnit.module( ".numberParser( [options] )", {
 		});
 		Globalize.locale( "en" );
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 QUnit.test( "should validate parameters", function( assert ) {

--- a/test/functional/number/number-to-parts-formatter.js
+++ b/test/functional/number/number-to-parts-formatter.js
@@ -20,7 +20,7 @@ function extraSetup() {
 }
 
 QUnit.module( ".numberToPartsFormatter( [options] )", {
-	setup: function() {
+	beforeEach: function() {
 		Globalize.load( likelySubtags, {
 			main: {
 				en: {}
@@ -28,7 +28,7 @@ QUnit.module( ".numberToPartsFormatter( [options] )", {
 		});
 		Globalize.locale( "en" );
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 QUnit.test( "should validate parameters", function( assert ) {

--- a/test/functional/number/parse-number.js
+++ b/test/functional/number/parse-number.js
@@ -31,7 +31,7 @@ function extraSetup() {
 }
 
 QUnit.module( ".parseNumber( value [, options] )", {
-	setup: function() {
+	beforeEach: function() {
 		Globalize.load( likelySubtags, {
 			main: {
 				ar: {},
@@ -51,7 +51,7 @@ QUnit.module( ".parseNumber( value [, options] )", {
 		zh = new Globalize( "zh-u-nu-native" );
 		Globalize.locale( "en" );
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 QUnit.test( "should validate parameters", function( assert ) {

--- a/test/functional/plural/plural-generator.js
+++ b/test/functional/plural/plural-generator.js
@@ -9,7 +9,7 @@ define([
 ], function( Globalize, likelySubtags, plurals, ordinals, util ) {
 
 QUnit.module( ".pluralGenerator()", {
-	setup: function() {
+	beforeEach: function() {
 		Globalize.load( likelySubtags, plurals, ordinals, {
 			main: {
 				en: {}
@@ -17,7 +17,7 @@ QUnit.module( ".pluralGenerator()", {
 		});
 		Globalize.locale( "en" );
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 });

--- a/test/functional/plural/plural.js
+++ b/test/functional/plural/plural.js
@@ -28,7 +28,7 @@ function extraSetup() {
 }
 
 QUnit.module( ".plural( value )", {
-	setup: function() {
+	beforeEach: function() {
 		Globalize.load( likelySubtags, {
 			main: {
 				en: {}
@@ -36,7 +36,7 @@ QUnit.module( ".plural( value )", {
 		});
 		Globalize.locale( "en" );
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 QUnit.test( "should validate parameters", function( assert ) {

--- a/test/functional/relative-time/format-relative-time.js
+++ b/test/functional/relative-time/format-relative-time.js
@@ -17,7 +17,7 @@ define( [
 var de, en;
 
 QUnit.module( ".fomatRelativeTime( value, unit [, options] ) - no CLDR", {
-	setup: function( ) {
+	beforeEach: function() {
 		Globalize.load( likelySubtags, {
 			main: {
 				en: {}
@@ -25,7 +25,7 @@ QUnit.module( ".fomatRelativeTime( value, unit [, options] ) - no CLDR", {
 		});
 		Globalize.locale( "en" );
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 QUnit.test( "should validate CLDR content", function( assert ) {
@@ -43,7 +43,7 @@ QUnit.test( "should un-register event listener", function( assert ) {
 });
 
 QUnit.module( ".formatRelativeTime( value, unit [, options] )", {
-	setup: function( ) {
+	beforeEach: function() {
 		Globalize.load( likelySubtags, enDateFields, deDateFields,
 			numberingSystems, enNumbers, deNumbers,
 			plurals );
@@ -51,7 +51,7 @@ QUnit.module( ".formatRelativeTime( value, unit [, options] )", {
 		de = new Globalize( "de" );
 		en = new Globalize( "en" );
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 QUnit.test( "should validate value argument presence", function( assert ) {

--- a/test/functional/relative-time/relative-time-formatter.js
+++ b/test/functional/relative-time/relative-time-formatter.js
@@ -17,7 +17,7 @@ define( [
 var en, de;
 
 QUnit.module( ".relativeTimeFormatter( unit [, options] ) - no CLDR", {
-	setup: function( ) {
+	beforeEach: function() {
 		Globalize.load( likelySubtags, {
 			main: {
 				en: {}
@@ -25,7 +25,7 @@ QUnit.module( ".relativeTimeFormatter( unit [, options] ) - no CLDR", {
 		});
 		Globalize.locale( "en" );
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 QUnit.test( "should validate CLDR content", function( assert ) {
@@ -35,7 +35,7 @@ QUnit.test( "should validate CLDR content", function( assert ) {
 });
 
 QUnit.module( ".relativeTimeFormatter( unit [, options] )", {
-	setup: function( ) {
+	beforeEach: function() {
 		Globalize.load( likelySubtags, enDateFields, deDateFields,
 			numberingSystems, enNumbers, deNumbers,
 			plurals );
@@ -43,7 +43,7 @@ QUnit.module( ".relativeTimeFormatter( unit [, options] )", {
 		en = new Globalize( "en" );
 		de = new Globalize( "de" );
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 QUnit.test( "should validate unit argument presence", function( assert ) {

--- a/test/functional/unit/format-unit.js
+++ b/test/functional/unit/format-unit.js
@@ -16,11 +16,11 @@ define( [
 var de, en;
 
 QUnit.module( ".formatUnit( value, unit, options ) - no CLDR", {
-	setup: function() {
+	beforeEach: function() {
 		Globalize.load( enUnitFields, likelySubtags );
 		Globalize.locale( "en" );
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 QUnit.test( "should validate CLDR content", function( assert ) {
@@ -30,13 +30,13 @@ QUnit.test( "should validate CLDR content", function( assert ) {
 });
 
 QUnit.module( ".formatUnit( value, unit, options )", {
-	setup: function() {
+	beforeEach: function() {
 		Globalize.load( enNumbers, deNumbers, enUnitFields, deUnitFields, likelySubtags,
 			numberingSystems, plurals );
 		de = new Globalize( "de" );
 		en = new Globalize( "en" );
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 QUnit.test( "should validate value argument presence", function( assert ) {

--- a/test/functional/unit/unit-formatter.js
+++ b/test/functional/unit/unit-formatter.js
@@ -16,11 +16,11 @@ define( [
 var de, en;
 
 QUnit.module( ".unitFormatter( unit, options ) - no CLDR", {
-	setup: function() {
+	beforeEach: function() {
 		Globalize.load( enUnitFields, likelySubtags );
 		Globalize.locale( "en" );
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 QUnit.test( "should validate CLDR content", function( assert ) {
@@ -30,14 +30,14 @@ QUnit.test( "should validate CLDR content", function( assert ) {
 });
 
 QUnit.module( ".unitFormatter( unit, options )", {
-	setup: function() {
+	beforeEach: function() {
 		Globalize.load( enNumbers, deNumbers, enUnitFields, deUnitFields, likelySubtags,
 			numberingSystems, plurals );
 		Globalize.locale( "en" );
 		de = new Globalize( "de" );
 		en = new Globalize( "en" );
 	},
-	teardown: util.resetCldrContent
+	afterEach: util.resetCldrContent
 });
 
 QUnit.test( "should validate unit argument presence", function( assert ) {

--- a/test/unit.html
+++ b/test/unit.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>Globalize Unit Tests</title>
-    <link rel="stylesheet" href="../external/qunit/qunit/qunit.css">
+    <link rel="stylesheet" href="../node_modules/qunit/qunit/qunit.css">
 </head>
 <body>
     <div id="qunit"></div>

--- a/test/unit.html
+++ b/test/unit.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8">

--- a/test/unit.js
+++ b/test/unit.js
@@ -53,7 +53,7 @@ require([
 	QUnit.start();
 }, function( error ) {
 	QUnit.test( "requirejs load failure", function( assert ) {
-		assert.ok( false, "requirejs failed to load: " + QUnit.jsDump.parse( error ) );
+		assert.ok( false, "requirejs failed to load: " + QUnit.dump.parse( error ) );
 	});
 	QUnit.start();
 });


### PR DESCRIPTION
See <https://qunitjs.com/upgrade-guide-2.x/>. Basically just two trivial renames that landed in QUnit 1.x with compat aliases that were removed in 2.0.

The branch contains two other changes:
1. To fix the commitplease build failure.
2. To pull in ~~an unmerged fix at https://github.com/rxaviers/zoned-date-time/pull/3~~ the updated version of `zoned-date-time` to address the ReferenceError about `module` being undefined.