### PR TITLE
cldr-data is now loaded from package.json

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,6 +1,3 @@
 {
-  "directory": "external",
-  "scripts": {
-    "postinstall": "node ./node_modules/cldr-data-downloader/bin/download.js -i external/cldr-data/index.json -o external/cldr-data/"
-  }
+  "directory": "external"
 }

--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,6 @@
     "cldrjs": "^0.5.4"
   },
   "devDependencies": {
-    "cldr-data": ">=25",
     "es5-shim": "3.4.0",
     "make-plural": "eemeli/make-plural.js#3.0.0",
     "messageformat": "SlexAxton/messageformat.js#v0.3.0-1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "globalize",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -642,6 +642,31 @@
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "cldr-data": {
+      "version": "36.0.0",
+      "resolved": "https://registry.npmjs.org/cldr-data/-/cldr-data-36.0.0.tgz",
+      "integrity": "sha512-F3n+9DUs41vhys8eF/hsCgkmYlgXMCiwaE75uGZjUbS/jkszBnLylXj7xW3bBlMU1d2IuAptpoNAb6lTCu/RSg==",
+      "dev": true,
+      "requires": {
+        "cldr-data-downloader": "0.3.x",
+        "glob": "5.x.x"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "cldrjs": "^0.5.4"
   },
   "devDependencies": {
+    "cldr-data": "^36.0.0",
     "cldr-data-downloader": "^0.3.1",
     "eslint-config-jquery": "3.0.0",
     "glob": "^7.1.2",

--- a/test/compiler/cases/currency.js
+++ b/test/compiler/cases/currency.js
@@ -4,20 +4,20 @@ module.exports = {
 
 		Globalize.load(
 			// core
-			require( "../../../external/cldr-data/supplemental/likelySubtags.json" ),
+			require( "../../../node_modules/cldr-data/supplemental/likelySubtags.json" ),
 			// currency
-			require( "../../../external/cldr-data/main/en/currencies.json" ),
-			require( "../../../external/cldr-data/main/de/currencies.json" ),
-			require( "../../../external/cldr-data/main/zh/currencies.json" ),
-			require( "../../../external/cldr-data/supplemental/currencyData.json" ),
+			require( "../../../node_modules/cldr-data/main/en/currencies.json" ),
+			require( "../../../node_modules/cldr-data/main/de/currencies.json" ),
+			require( "../../../node_modules/cldr-data/main/zh/currencies.json" ),
+			require( "../../../node_modules/cldr-data/supplemental/currencyData.json" ),
 			// number
-			require( "../../../external/cldr-data/main/en/numbers.json" ),
-			require( "../../../external/cldr-data/main/de/numbers.json" ),
-			require( "../../../external/cldr-data/main/zh/numbers.json" ),
-			require( "../../../external/cldr-data/supplemental/numberingSystems.json" ),
+			require( "../../../node_modules/cldr-data/main/en/numbers.json" ),
+			require( "../../../node_modules/cldr-data/main/de/numbers.json" ),
+			require( "../../../node_modules/cldr-data/main/zh/numbers.json" ),
+			require( "../../../node_modules/cldr-data/supplemental/numberingSystems.json" ),
 			// plural
-			require( "../../../external/cldr-data/supplemental/plurals.json" ),
-			require( "../../../external/cldr-data/supplemental/ordinals.json" )
+			require( "../../../node_modules/cldr-data/supplemental/plurals.json" ),
+			require( "../../../node_modules/cldr-data/supplemental/ordinals.json" )
 		);
 
 		return Globalize;

--- a/test/compiler/cases/date.js
+++ b/test/compiler/cases/date.js
@@ -4,16 +4,16 @@ module.exports = {
 
 		Globalize.load(
 			// core
-			require( "../../../external/cldr-data/supplemental/likelySubtags.json" ),
+			require( "../../../node_modules/cldr-data/supplemental/likelySubtags.json" ),
 			// date
-			require( "../../../external/cldr-data/main/en/ca-gregorian.json" ),
-			require( "../../../external/cldr-data/main/en/timeZoneNames.json" ),
-			require( "../../../external/cldr-data/supplemental/metaZones.json" ),
-			require( "../../../external/cldr-data/supplemental/timeData.json" ),
-			require( "../../../external/cldr-data/supplemental/weekData.json" ),
+			require( "../../../node_modules/cldr-data/main/en/ca-gregorian.json" ),
+			require( "../../../node_modules/cldr-data/main/en/timeZoneNames.json" ),
+			require( "../../../node_modules/cldr-data/supplemental/metaZones.json" ),
+			require( "../../../node_modules/cldr-data/supplemental/timeData.json" ),
+			require( "../../../node_modules/cldr-data/supplemental/weekData.json" ),
 			// number
-			require( "../../../external/cldr-data/main/en/numbers.json" ),
-			require( "../../../external/cldr-data/supplemental/numberingSystems.json" )
+			require( "../../../node_modules/cldr-data/main/en/numbers.json" ),
+			require( "../../../node_modules/cldr-data/supplemental/numberingSystems.json" )
 		);
 
 		Globalize.loadTimeZone( require( "iana-tz-data" ) );

--- a/test/compiler/cases/message.js
+++ b/test/compiler/cases/message.js
@@ -4,7 +4,7 @@ module.exports = {
 
 		Globalize.load(
 			// core
-			require( "../../../external/cldr-data/supplemental/likelySubtags.json" )
+			require( "../../../node_modules/cldr-data/supplemental/likelySubtags.json" )
 		);
 
 		Globalize.loadMessages({

--- a/test/compiler/cases/number.js
+++ b/test/compiler/cases/number.js
@@ -4,13 +4,13 @@ module.exports = {
 
 		Globalize.load(
 			// core
-			require( "../../../external/cldr-data/supplemental/likelySubtags.json" ),
+			require( "../../../node_modules/cldr-data/supplemental/likelySubtags.json" ),
 			// number
-			require( "../../../external/cldr-data/main/ar/numbers.json" ),
-			require( "../../../external/cldr-data/main/en/numbers.json" ),
-			require( "../../../external/cldr-data/main/es/numbers.json" ),
-			require( "../../../external/cldr-data/main/zh/numbers.json" ),
-			require( "../../../external/cldr-data/supplemental/numberingSystems.json" )
+			require( "../../../node_modules/cldr-data/main/ar/numbers.json" ),
+			require( "../../../node_modules/cldr-data/main/en/numbers.json" ),
+			require( "../../../node_modules/cldr-data/main/es/numbers.json" ),
+			require( "../../../node_modules/cldr-data/main/zh/numbers.json" ),
+			require( "../../../node_modules/cldr-data/supplemental/numberingSystems.json" )
 		);
 
 		return Globalize;

--- a/test/compiler/cases/plural.js
+++ b/test/compiler/cases/plural.js
@@ -4,10 +4,10 @@ module.exports = {
 
 		Globalize.load(
 			// core
-			require( "../../../external/cldr-data/supplemental/likelySubtags.json" ),
+			require( "../../../node_modules/cldr-data/supplemental/likelySubtags.json" ),
 			// plural
-			require( "../../../external/cldr-data/supplemental/plurals.json" ),
-			require( "../../../external/cldr-data/supplemental/ordinals.json" )
+			require( "../../../node_modules/cldr-data/supplemental/plurals.json" ),
+			require( "../../../node_modules/cldr-data/supplemental/ordinals.json" )
 		);
 
 		return Globalize;

--- a/test/compiler/cases/relative-time.js
+++ b/test/compiler/cases/relative-time.js
@@ -4,17 +4,17 @@ module.exports = {
 
 		Globalize.load(
 			// core
-			require( "../../../external/cldr-data/supplemental/likelySubtags.json" ),
+			require( "../../../node_modules/cldr-data/supplemental/likelySubtags.json" ),
 			// relative time
-			require( "../../../external/cldr-data/main/en/dateFields.json" ),
-			require( "../../../external/cldr-data/main/de/dateFields.json" ),
+			require( "../../../node_modules/cldr-data/main/en/dateFields.json" ),
+			require( "../../../node_modules/cldr-data/main/de/dateFields.json" ),
 			// number
-			require( "../../../external/cldr-data/main/en/numbers.json" ),
-			require( "../../../external/cldr-data/main/de/numbers.json" ),
-			require( "../../../external/cldr-data/supplemental/numberingSystems.json" ),
+			require( "../../../node_modules/cldr-data/main/en/numbers.json" ),
+			require( "../../../node_modules/cldr-data/main/de/numbers.json" ),
+			require( "../../../node_modules/cldr-data/supplemental/numberingSystems.json" ),
 			// plural
-			require( "../../../external/cldr-data/supplemental/plurals.json" ),
-			require( "../../../external/cldr-data/supplemental/ordinals.json" )
+			require( "../../../node_modules/cldr-data/supplemental/plurals.json" ),
+			require( "../../../node_modules/cldr-data/supplemental/ordinals.json" )
 		);
 
 		return Globalize;

--- a/test/compiler/cases/unit.js
+++ b/test/compiler/cases/unit.js
@@ -4,17 +4,17 @@ module.exports = {
 
 		Globalize.load(
 			// core
-			require( "../../../external/cldr-data/supplemental/likelySubtags.json" ),
+			require( "../../../node_modules/cldr-data/supplemental/likelySubtags.json" ),
 			// unit
-			require( "../../../external/cldr-data/main/en/units.json" ),
-			require( "../../../external/cldr-data/main/de/units.json" ),
+			require( "../../../node_modules/cldr-data/main/en/units.json" ),
+			require( "../../../node_modules/cldr-data/main/de/units.json" ),
 			// number
-			require( "../../../external/cldr-data/main/en/numbers.json" ),
-			require( "../../../external/cldr-data/main/de/numbers.json" ),
-			require( "../../../external/cldr-data/supplemental/numberingSystems.json" ),
+			require( "../../../node_modules/cldr-data/main/en/numbers.json" ),
+			require( "../../../node_modules/cldr-data/main/de/numbers.json" ),
+			require( "../../../node_modules/cldr-data/supplemental/numberingSystems.json" ),
 			// plural
-			require( "../../../external/cldr-data/supplemental/plurals.json" ),
-			require( "../../../external/cldr-data/supplemental/ordinals.json" )
+			require( "../../../node_modules/cldr-data/supplemental/plurals.json" ),
+			require( "../../../node_modules/cldr-data/supplemental/ordinals.json" )
 		);
 
 		return Globalize;

--- a/test/config.js
+++ b/test/config.js
@@ -3,7 +3,7 @@ var requirejs = {
 	paths: {
 		qunit: "../node_modules/qunit/qunit/qunit",
 		cldr: "../external/cldrjs/dist/cldr",
-		"cldr-data": "../external/cldr-data",
+		"cldr-data": "../node_modules/cldr-data",
 		globalize: "../dist/globalize",
 		"iana-tz-data": "../node_modules/iana-tz-data/iana-tz-data",
 		json: "../external/requirejs-plugins/src/json",

--- a/test/functional/date/format-date-to-parts.js
+++ b/test/functional/date/format-date-to-parts.js
@@ -296,7 +296,7 @@ QUnit.test( "should format skeleton to parts", function( assert ) {
 	assert.deepEqual( Globalize( "pt" ).formatDateToParts( date, { skeleton: "Ehms" } ), [
 		{
 			"type": "weekday",
-			"value": "qua"
+			"value": "qua."
 		},
 		{
 			"type": "literal",
@@ -335,7 +335,7 @@ QUnit.test( "should format skeleton to parts", function( assert ) {
 	assert.deepEqual( Globalize( "pt" ).formatDateToParts( date, { skeleton: "GyMMMEd" } ), [
 		{
 			"type": "weekday",
-			"value": "qua"
+			"value": "qua."
 		},
 		{
 			"type": "literal",
@@ -351,7 +351,7 @@ QUnit.test( "should format skeleton to parts", function( assert ) {
 		},
 		{
 			"type": "month",
-			"value": "set"
+			"value": "set."
 		},
 		{
 			"type": "literal",

--- a/test/functional/date/format-date.js
+++ b/test/functional/date/format-date.js
@@ -152,8 +152,8 @@ QUnit.test( "should format skeleton", function( assert ) {
 	assert.equal( ar.formatDate( date, { skeleton: "yQQQ" } ), "الربع الثالث ٢٠١٠" );
 
 	// Via instance .formatDate().
-	assert.equal( Globalize( "pt" ).formatDate( date, { skeleton: "Ehms" } ), "qua, 5:35:07 PM" );
-	assert.equal( Globalize( "pt" ).formatDate( date, { skeleton: "GyMMMEd" } ), "qua, 15 de set de 2010 d.C." );
+	assert.equal( Globalize( "pt" ).formatDate( date, { skeleton: "Ehms" } ), "qua., 5:35:07 PM" );
+	assert.equal( Globalize( "pt" ).formatDate( date, { skeleton: "GyMMMEd" } ), "qua., 15 de set. de 2010 d.C." );
 });
 
 QUnit.test( "should format time presets", function( assert ) {
@@ -195,7 +195,7 @@ QUnit.test( "should format date in various timezones", function( assert ) {
 
 	assert.equal(
 		Globalize.formatDate( date, { datetime: "long", timeZone: "Etc/UTC" } ),
-		"September 15, 2010 at 4:35:07 PM GMT"
+		"September 15, 2010 at 4:35:07 PM UTC"
 	);
 	assert.equal(
 		Globalize.formatDate( date, { datetime: "long", timeZone: "Europe/Berlin" } ),

--- a/test/functional/date/parse-date.js
+++ b/test/functional/date/parse-date.js
@@ -155,7 +155,7 @@ QUnit.test( "should parse skeleton", function( assert ) {
 	date = startOf( date, "day" );
 	assertParseDate( assert, "Wed, Sep 15, 2010 AD", { skeleton: "GyMMMEd" }, date );
 	assertParseDate( assert, "9/15/2010", { skeleton: "yMd" }, date );
-	assertParseDate( assert, "الأربعاء، ١٥ سبتمبر، ٢٠١٠ م", { skeleton: "GyMMMEd" }, date, ar );
+	assertParseDate( assert, "الأربعاء، ١٥ سبتمبر ٢٠١٠ م", { skeleton: "GyMMMEd" }, date, ar );
 
 	// Loose matching: ignore control characters.
 	assertParseDate( assert, "١٥/٩/٢٠١٠", { skeleton: "yMd" }, date, ar );
@@ -166,7 +166,7 @@ QUnit.test( "should parse skeleton", function( assert ) {
 	assertParseDate( assert, "الربع الثالث ٢٠١٠", { skeleton: "yQQQ" }, date, ar );
 
 	// Via instance globalize.parseDate().
-	assert.deepEqual( Globalize( "pt" ).parseDate( "2010 T3", { skeleton: "yQQQ" } ), date, "{ skeleton: \"yQQQ\" }" );
+	assert.deepEqual( Globalize( "pt" ).parseDate( "T3 de 2010", { skeleton: "yQQQ" } ), date, "{ skeleton: \"yQQQ\" }" );
 });
 
 QUnit.test( "should parse time presets", function( assert ) {

--- a/test/functional/number/format-number-to-parts.js
+++ b/test/functional/number/format-number-to-parts.js
@@ -329,7 +329,7 @@ QUnit.test( "should format percent style", function( assert ) {
 		},
 		{
 			"type": "percentSign",
-			"value": "٪"
+			"value": "٪؜"
 		}
 	]);
 });

--- a/test/functional/number/format-number.js
+++ b/test/functional/number/format-number.js
@@ -123,7 +123,7 @@ QUnit.test( "should format percent style", function( assert ) {
 	extraSetup();
 
 	assert.equal( Globalize.formatNumber( pi, { style: "percent" } ), "314%" );
-	assert.equal( Globalize( "ar" ).formatNumber( pi, { style: "percent" } ), "٣١٤٪" );
+	assert.equal( Globalize( "ar" ).formatNumber( pi, { style: "percent" } ), "٣١٤٪؜" );
 });
 
 });

--- a/test/unit/date/expand-pattern.js
+++ b/test/unit/date/expand-pattern.js
@@ -41,7 +41,7 @@ QUnit.test( "should expand {skeleton: \"<skeleton>\"}", function( assert ) {
 	// Preferred hour (j).
 	assert.expandPattern( en, { skeleton: "jmm" }, "h:mm a" );
 	assert.expandPattern( de, { skeleton: "jmm" }, "HH:mm" );
-	assert.expandPattern( ru, { skeleton: "jmm" }, "H:mm" );
+	assert.expandPattern( ru, { skeleton: "jmm" }, "HH:mm" );
 
 	// Best matches the whole skeleton.
 	assert.expandPattern( en, { skeleton: "hhmm" }, "hh:mm a" );

--- a/test/unit/number/format-properties.js
+++ b/test/unit/number/format-properties.js
@@ -66,6 +66,7 @@ QUnit.test( "should return nanSymbol", function( assert ) {
 });
 
 QUnit.test( "should return symbolMap", function( assert ) {
+	// debugger;
 	assert.deepEqual( properties( "0", es )[ 18 ], {
 		"%": "%",
 		"+": "+",
@@ -77,11 +78,11 @@ QUnit.test( "should return symbolMap", function( assert ) {
 	});
 
 	assert.deepEqual( properties( "0", fa )[ 18 ], {
-		"%": "٪",
-		"+": "\u200e+\u200e",
-		",": "٬",
-		"-": "\u200e−",
 		".": "٫",
+		",": "٬",
+		"%": "٪",
+		"+": "‎+",
+		"-": "‎−",
 		"E": "×۱۰^",
 		"‰": "؉"
 	});

--- a/test/unit/number/format.js
+++ b/test/unit/number/format.js
@@ -1426,7 +1426,7 @@ QUnit.test( "should localize percent symbol (%)", function( assert ) {
 		},
 		{
 			"type": "percentSign",
-			"value": "٪"
+			"value": "٪؜"
 		}
 	]);
 });

--- a/test/unit/unit/format.js
+++ b/test/unit/unit/format.js
@@ -153,8 +153,8 @@ QUnit.test( "Compound form (narrow)", function( assert ) {
 QUnit.test( "Compound form (without precomputed) in language without 'one' unit", function( assert ) {
 	assert.unitFormat( 1, "length-foot-per-second", { form: "long" }, "1 フィート毎秒", "ja" );
 	assert.unitFormat( 100, "length-foot-per-second", { form: "long" }, "100 フィート毎秒", "ja" );
-	assert.unitFormat( 1, "megabyte-per-second", { form: "narrow" }, "1MB/秒", "ja" );
-	assert.unitFormat( 100, "megabyte-per-second", { form: "narrow" }, "100MB/秒", "ja" );
+	assert.unitFormat( 1, "megabyte-per-second", { form: "narrow" }, "1MB/s", "ja" );
+	assert.unitFormat( 100, "megabyte-per-second", { form: "narrow" }, "100MB/s", "ja" );
 
 	assert.unitFormat( 1.2345678910, "megabyte-per-second",
 		{
@@ -163,7 +163,7 @@ QUnit.test( "Compound form (without precomputed) in language without 'one' unit"
 				return number.toFixed(1);
 			}
 		},
-		"1.2MB/秒", "ja" );
+		"1.2MB/s", "ja" );
 });
 
 });


### PR DESCRIPTION
Addresses #811 and moves the `cldr-data` package to npm. The latest version of the package is 36 whether the latest version of cldr is 40 now, but i guess it's now closer rather than 25 :D

Anyways I did this one in order to obtain the dayPeriods data which is required to resolve #544. 