### PR TITLE
chore: remove git.io

### DIFF
--- a/src/build/intro-core-runtime.js
+++ b/src/build/intro-core-runtime.js
@@ -11,7 +11,7 @@
  */
 /*!
  * Globalize Runtime v@VERSION @DATE Released under the MIT license
- * http://git.io/TrdQbw
+ * https://github.com/globalizejs/globalize
  */
 (function( root, factory ) {
 

--- a/src/build/intro-core.js
+++ b/src/build/intro-core.js
@@ -11,7 +11,7 @@
  */
 /*!
  * Globalize v@VERSION @DATE Released under the MIT license
- * http://git.io/TrdQbw
+ * https://github.com/globalizejs/globalize
  */
 (function( root, factory ) {
 

--- a/src/build/intro-currency-runtime.js
+++ b/src/build/intro-currency-runtime.js
@@ -11,7 +11,7 @@
  */
 /*!
  * Globalize Runtime v@VERSION @DATE Released under the MIT license
- * http://git.io/TrdQbw
+ * https://github.com/globalizejs/globalize
  */
 (function( root, factory ) {
 

--- a/src/build/intro-date-runtime.js
+++ b/src/build/intro-date-runtime.js
@@ -11,7 +11,7 @@
  */
 /*!
  * Globalize Runtime v@VERSION @DATE Released under the MIT license
- * http://git.io/TrdQbw
+ * https://github.com/globalizejs/globalize
  */
 (function( root, factory ) {
 

--- a/src/build/intro-date.js
+++ b/src/build/intro-date.js
@@ -11,7 +11,7 @@
  */
 /*!
  * Globalize v@VERSION @DATE Released under the MIT license
- * http://git.io/TrdQbw
+ * https://github.com/globalizejs/globalize
  */
 (function( root, factory ) {
 

--- a/src/build/intro-message-runtime.js
+++ b/src/build/intro-message-runtime.js
@@ -11,7 +11,7 @@
  */
 /*!
  * Globalize Runtime v@VERSION @DATE Released under the MIT license
- * http://git.io/TrdQbw
+ * https://github.com/globalizejs/globalize
  */
 (function( root, factory ) {
 

--- a/src/build/intro-message.js
+++ b/src/build/intro-message.js
@@ -11,7 +11,7 @@
  */
 /*!
  * Globalize v@VERSION @DATE Released under the MIT license
- * http://git.io/TrdQbw
+ * https://github.com/globalizejs/globalize
  */
 (function( root, factory ) {
 

--- a/src/build/intro-number-runtime.js
+++ b/src/build/intro-number-runtime.js
@@ -11,7 +11,7 @@
  */
 /*!
  * Globalize Runtime v@VERSION @DATE Released under the MIT license
- * http://git.io/TrdQbw
+ * https://github.com/globalizejs/globalize
  */
 (function( root, factory ) {
 

--- a/src/build/intro-number.js
+++ b/src/build/intro-number.js
@@ -11,7 +11,7 @@
  */
 /*!
  * Globalize v@VERSION @DATE Released under the MIT license
- * http://git.io/TrdQbw
+ * https://github.com/globalizejs/globalize
  */
 (function( root, factory ) {
 

--- a/src/build/intro-plural-runtime.js
+++ b/src/build/intro-plural-runtime.js
@@ -11,7 +11,7 @@
  */
 /*!
  * Globalize Runtime v@VERSION @DATE Released under the MIT license
- * http://git.io/TrdQbw
+ * https://github.com/globalizejs/globalize
  */
 (function( root, factory ) {
 

--- a/src/build/intro-plural.js
+++ b/src/build/intro-plural.js
@@ -11,7 +11,7 @@
  */
 /*!
  * Globalize v@VERSION @DATE Released under the MIT license
- * http://git.io/TrdQbw
+ * https://github.com/globalizejs/globalize
  */
 (function( root, factory ) {
 

--- a/src/build/intro-relative-time-runtime.js
+++ b/src/build/intro-relative-time-runtime.js
@@ -11,7 +11,7 @@
  */
 /*!
  * Globalize Runtime v@VERSION @DATE Released under the MIT license
- * http://git.io/TrdQbw
+ * https://github.com/globalizejs/globalize
  */
 (function( root, factory ) {
 

--- a/src/build/intro-relative-time.js
+++ b/src/build/intro-relative-time.js
@@ -11,7 +11,7 @@
  */
 /*!
  * Globalize v@VERSION @DATE Released under the MIT license
- * http://git.io/TrdQbw
+ * https://github.com/globalizejs/globalize
  */
 (function( root, factory ) {
 

--- a/src/build/intro-unit-runtime.js
+++ b/src/build/intro-unit-runtime.js
@@ -11,7 +11,7 @@
  */
 /*!
  * Globalize Runtime v@VERSION @DATE Released under the MIT license
- * http://git.io/TrdQbw
+ * https://github.com/globalizejs/globalize
  */
 (function( root, factory ) {
 

--- a/src/build/intro-unit.js
+++ b/src/build/intro-unit.js
@@ -11,7 +11,7 @@
  */
 /*!
  * Globalize v@VERSION @DATE Released under the MIT license
- * http://git.io/TrdQbw
+ * https://github.com/globalizejs/globalize
  */
 (function( root, factory ) {
 

--- a/src/build/intro.min.js
+++ b/src/build/intro.min.js
@@ -1,4 +1,4 @@
 /*!
  * Globalize v@VERSION @DATE Released under the MIT license
- * http://git.io/TrdQbw
+ * https://github.com/globalizejs/globalize
  */


### PR DESCRIPTION
All links on git.io will stop redirecting after April 29, 2022.

- https://github.blog/changelog/2022-04-25-git-io-deprecation/