### PR TITLE
Add support for literals in compact patterns

### DIFF
--- a/src/number/format.js
+++ b/src/number/format.js
@@ -174,11 +174,11 @@ return function( number, properties, pluralGenerator ) {
 		// format-properties.
 		aux = function( string ) {
 			var parts = [];
-			string.replace( /(\s+)|([^\s0]+)/g, function( _garbage, space, compact ) {
+			string.replace( /('(?:[^']|'')+'|''|\s+)|([^\s'0]+)/g, function( _garbage, literal, compact ) {
 
 				// Literals
-				if ( space ) {
-					partsPush( parts, "literal", space );
+				if ( literal ) {
+					partsPush( parts, "literal", removeLiteralQuotes( literal ) );
 					return;
 				}
 

--- a/test/functional/currency/format-currency.js
+++ b/test/functional/currency/format-currency.js
@@ -1,5 +1,7 @@
 define([
 	"globalize",
+	"json!cldr-data/main/de/currencies.json",
+	"json!cldr-data/main/de/numbers.json",
 	"json!cldr-data/main/en/currencies.json",
 	"json!cldr-data/main/en/numbers.json",
 	"json!cldr-data/supplemental/currencyData.json",
@@ -9,13 +11,15 @@ define([
 
 	"globalize/currency",
 	"globalize/number"
-], function( Globalize, enCurrencies, enNumbers, currencyData, likelySubtags, plurals, util ) {
+], function( Globalize, deCurrencies, deNumbers, enCurrencies, enNumbers, currencyData, likelySubtags, plurals, util ) {
 
 var teslaS = 69900;
 
 function extraSetup() {
 	Globalize.load(
 		currencyData,
+		deCurrencies,
+		deNumbers,
 		enCurrencies,
 		enNumbers,
 		plurals
@@ -71,6 +75,13 @@ QUnit.test( "should validate CLDR content", function( assert ) {
 QUnit.test( "should format currencies", function( assert ) {
 	extraSetup();
 	assert.equal( Globalize.formatCurrency( teslaS, "USD" ), "$69,900.00" );
+});
+
+QUnit.test( "should format currencies with string literals in the format", function( assert ) {
+	// https://github.com/globalizejs/globalize/issues/917
+	extraSetup();
+	var de = Globalize( "de" );
+	assert.equal( de.currencyFormatter( "EUR", { compact: "short" } )( 1210000 ), "1\u00A0Mio.\u00A0€" );
 });
 
 });


### PR DESCRIPTION
### What are you trying to accomplish?

The code was not accounting for the possibility of string literals in compact patterns ([example](https://github.com/unicode-org/cldr/blob/ae7926603d478433266d79b88a8d05d30b7da3cf/common/main/de.xml#L6629)).

This was causing issues with the compact rendering of numbers in some languages.  

### What approach did you choose and why?

Copied the same regex for detecting literals in the `stringToParts` function, and applied it to `compactPattern`.

### What should reviewers focus on?

That the regex makes sense.

It's safe to add the `'` to the negated character class, since a `'` is either the start of a string literal or should be escaped with a second `'`, both of which are covered by the first case in the alternation.  

### The impact of these changes

Fixes https://github.com/globalizejs/globalize/issues/917
Fixes https://github.com/globalizejs/globalize/issues/946